### PR TITLE
update rivendell document to ZenDesk

### DIFF
--- a/markdowns/integration-android.md
+++ b/markdowns/integration-android.md
@@ -18,7 +18,7 @@ maven { url "https://dl.bintray.com/yodo1/android-sdk" }
 ### 2. Open your app-level `build.gradle` and add the relevant code.
 #### 2.1 Add a Gradle dependency
 ```groovy
-implementation 'com.yodo1.mas:google:4.0.0.0'
+implementation 'com.yodo1.mas:google:4.0.0.0' 
 ```
 
 #### 2.2 Add the `compileOptions` property to the `Android` section
@@ -128,7 +128,7 @@ Initialize the SDK in the `onCreate` method of `Activity`
 ```java
 protected void onCreate() {
   super.onCreate();
-	Yodo1Mas.getInstance().init(this, "Your AppId", new Yodo1Mas.InitListener() {
+	Yodo1Mas.getInstance().init(this, "Your AppId", new Yodo1Mas.InitListener() { 
 	    @Override
 	    public void onMasInitSuccessful() {
 	        // 初始化成功
@@ -150,7 +150,7 @@ If you're using ProGuard with the MAS SDK, add the following code to your ProGua
 -keeppackagenames com.yodo1.**
 -keep class com.yodo1.** { *; }
 -keep class com.yodo1.mas.** { *; }
--keep class com.yodo1.mas.ads.** {*;}
+-keep class com.yodo1.mas.ads.** {*;} 
 -keep class com.yodo1.mas.error.** { *; }
 -keep class com.yodo1.mas.event.** { *; }
 -keep public class * extends com.yodo1.mas.mediation.Yodo1MasAdapterBase

--- a/markdowns/integration-ios.md
+++ b/markdowns/integration-ios.md
@@ -24,7 +24,7 @@ Please open the project's `Podfile` file and add the following code to the targe
 source 'https://github.com/Yodo1Games/MAS-Spec.git'
 source 'https://github.com/Yodo1Games/Yodo1Spec.git'
 
-pod 'Yodo1MasSDK', '~> 4.0.0.0'
+pod 'Yodo1MasSDK', '~> 4.0.0.0' 
 ```
 
 Execute the following command in `Terminal` :

--- a/markdowns/integration-unity.md
+++ b/markdowns/integration-unity.md
@@ -6,7 +6,7 @@
 
 ## The Integration Steps
 
-### 1. Download [Unity Plugin](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-4.0.0.0.unitypackage)
+### 1. Download [Unity Plugin](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-4.0.0.0.unitypackage) 
 > * MAS supports Unity 2017.4.37f1+ LTS version, 2018 and 2019 common maintained LTS Unity version and above.
 > * [Jetifier](https://developer.android.com/jetpack/androidx/releases/jetifier) is required for Android builds and can be enabled by selecting ***Assets > External Dependency Manager > Android Resolver > Settings > Use Jetifier***
 > * `CocoaPods` is required for iOS builds and can be installed following the instructions [here](https://guides.cocoapods.org/using/getting-started.html#getting-started)
@@ -114,7 +114,7 @@ classpath com.android.tools.build:gradle:x.x.x
 
 If you are on Unity 2017.4 or below, please ensure that you are on at least 2017.4.40 which uses a compatible version of the Gradle Plugin by default.
 
-Detailed steps for different versions of Unity can be found [here](android-manifest-merging-errors-queries.md).
+Detailed steps for different versions of Unity can be found [here](android-manifest-merging-errors-queries.md). 
 
 ## Interstitial Integration
 ### 1. Set the interstitial ad delegate method


### PR DESCRIPTION
#### For Unity

1.Download Unity Plugin

GitHub: https://github.com/Yodo1Games/MAS-Documents/blob/beta/markdowns/integration-unity.md#1-download-unity-plugin

ZenDesk: https://support.yodo1.com/hc/en-us/articles/1500001982341-Unity-Integration 

Change the Unity Plugin's link from 
https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-0.0.0.13-beta.unitypackage to https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-4.0.0.0.unitypackage

2.Page is missing
GitHub: https://github.com/Yodo1Games/MAS-Documents/blob/beta/markdowns/integration-unity.md#7-admob-android-manifest-merging-errors

ZenDesk: https://support.yodo1.com/hc/en-us/articles/1500001982341-Unity-Integration, at the very bottom of the document:

- Detailed steps for different versions of Unity can be found here.  

The link of 'here' should not be GitHub link, Please add a new page link in ZenDesk.

#### For iOS

GitHub: https://github.com/Yodo1Games/MAS-Documents/blob/beta/markdowns/integration-ios.md#12-import-the-ios-sdk-into-the-project

ZenDesk: https://support.yodo1.com/hc/en-us/articles/360060558854-iOS-Integration 

Change the SDK version from
```
pod 'Yodo1MasSDK', '~> 0.0.0.7-beta'
```
to
```
pod 'Yodo1MasSDK', '~> 4.0.0.0'
```

#### For Android

1.Android SDK Version

GitHub: https://github.com/Yodo1Games/MAS-Documents/blob/beta/markdowns/integration-android.md#21-add-a-gradle-dependency

ZenDesk: https://support.yodo1.com/hc/en-us/articles/1500002038322-Android-SDK-Integration-

Change the SDK version from
```
implementation 'com.yodo1.mas:google:0.0.0.13-beta'
```
to
```
implementation 'com.yodo1.mas:google:4.0.0.0'
```

2.Android ProGuard

GitHub: https://github.com/Yodo1Games/MAS-Documents/blob/beta/markdowns/integration-android.md#10-proguard

ZenDesk: https://support.yodo1.com/hc/en-us/articles/1500002038322

- 10-proguard content in GitHub updated and need update to ZenDesk