### PR TITLE
4.0.0.3

### DIFF
--- a/markdowns/integration-android.md
+++ b/markdowns/integration-android.md
@@ -18,7 +18,7 @@ maven { url "https://dl.bintray.com/yodo1/android-sdk" }
 ### 2. Open your app-level `build.gradle` and add the relevant code.
 #### 2.1 Add a Gradle dependency
 ```groovy
-implementation 'com.yodo1.mas:google:4.0.0.2'
+implementation 'com.yodo1.mas:google:4.0.0.3'
 ```
 
 #### 2.2 Add the `compileOptions` property to the `Android` section

--- a/markdowns/integration-ios.md
+++ b/markdowns/integration-ios.md
@@ -29,7 +29,7 @@ source 'https://github.com/Yodo1Games/MAS-Spec.git'
 source 'https://github.com/Yodo1Games/Yodo1Spec.git'
 
 pod 'FBSDKCoreKit' # If you have introduced FBSDKCoreKit, please ignore
-pod 'Yodo1MasSDK', '~> 4.0.0.2'
+pod 'Yodo1MasSDK', '~> 4.0.0.3'
 ```
 
 Execute the following command in `Terminal` :

--- a/markdowns/integration-unity.md
+++ b/markdowns/integration-unity.md
@@ -10,7 +10,7 @@
 
 ## The Integration Steps
 
-### 1. Download [Unity Plugin 4.0.0.2](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-4.0.0.2.unitypackage)
+### 1. Download [Unity Plugin 4.0.0.3](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-4.0.0.3.unitypackage)
 > * MAS supports Unity 2017.4.37f1+ LTS version, 2018.4.30f1+ LTS version, 2019.41f18+ LTS version, 2020 all version and above.
 > * [Jetifier](https://developer.android.com/jetpack/androidx/releases/jetifier) is required for Android builds and can be enabled by selecting ***Assets > External Dependency Manager > Android Resolver > Settings > Use Jetifier***
 > * `CocoaPods` is required for iOS builds and can be installed following the instructions [here](https://guides.cocoapods.org/using/getting-started.html#getting-started), please use version 1.8 and above.


### PR DESCRIPTION
1.integration-android.md
before
implementation 'com.yodo1.mas:google:4.0.0.2'
after
implementation 'com.yodo1.mas:google:4.0.0.3'

2.integration-ios.md
before
```
pod 'Yodo1MasSDK', '~> 4.0.0.2'
```
after
```
pod 'Yodo1MasSDK', '~> 4.0.0.3'
```

Add new content above "the Integration Steps", the content is as follows:
"Please upgrade to Firebase 7.0.0 and above if you are using Firebase, lower Firebase will not be probably compatible with AdMob since we are using the most updated Admob. According to Admob, Firebase needs to be updated to match the Admob version. And this update will also improve your general SDK integration process for long-term"

3.integration-unity.md
before
```
- To upgrade from an older SDK to MAS SDK v2, you must remove all the contents of the old SDK as following:`Assets/Plugins/iOS/Yodo1Ads`
```
after
```
- To upgrade from an older SDK to MAS SDK v2, you must remove all the contents of the old SDK as following:</br>
 - Assets/Plugins/iOS/Yodo1Ads
 - Assets/Plugins/Android/Yodo1Ads
 - Assets/Yodo1Ads
 ```

before
Download [Unity Plugin 4.0.0.1](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-4.0.0.2.unitypackage)
after
Download [Unity Plugin 4.0.0.3](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-4.0.0.3.unitypackage)

before
`CocoaPods` is required for iOS builds and can be installed following the instructions [here](https://guides.cocoapods.org/using/getting-started.html#getting-started)
after
`CocoaPods` is required for iOS builds and can be installed following the instructions [here](https://guides.cocoapods.org/using/getting-started.html#getting-started), please use version 1.8 and above.


Add new content above "the Integration Steps", the content is as follow:
"Please upgrade to Firebase 7.0.0 and above if you are using Firebase, lower Firebase will not be probably compatible with AdMob since we are using the most updated Admob. According to Admob, Firebase needs to be updated to match the Admob version. And this update will also improve your general SDK integration process for long-term"

Add new content above "3.2 Set iOS Configuration", the content is as follow:
"**Important!** Invalid AdMob AppID will cause a crash, please make sure to fetch the AdMob App ID from MAS dashboard"

Add new content above "Support AndroidX", the content is as follow:
"**Important!** Invalid AdMob AppID will cause a crash, please make sure to fetch the AdMob App ID from MAS dashboard"
