### PR TITLE
Add Google Families Policy Edition doc

### DIFF
--- a/markdowns/integration-unity.md
+++ b/markdowns/integration-unity.md
@@ -10,7 +10,7 @@ If you have not integrated, please read the following documents
 
 ## The Integration Steps
 
-### 1. Download [Unity Plugin 4.0.1.0](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-4.0.1.0.unitypackage)
+### 1. Download [Unity Plugin 4.0.1.0](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-4.0.1.0.unitypackage) Or Google Families Policy Edition [Unity Plugin 4.0.1.0](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-gp-family-policy-4.0.1.0.unitypackage)
 > * MAS supports Unity 2017.4.37f1+ LTS version, 2018.4.30f1+ LTS version, 2019.41f18+ LTS version, 2020 all version and above.
 > * [Jetifier](https://developer.android.com/jetpack/androidx/releases/jetifier) is required for Android builds and can be enabled by selecting ***Assets > External Dependency Manager > Android Resolver > Settings > Use Jetifier***
 > * `CocoaPods` is required for iOS builds and can be installed following the instructions [here](https://guides.cocoapods.org/using/getting-started.html#getting-started), please use version 1.8 and above.
@@ -18,6 +18,12 @@ If you have not integrated, please read the following documents
 > * The Unity plugin contains Sample code. The path is `/Assets/Yodo1/MAS/Sample`</br>
 
 Please upgrade to Firebase 7.0.0 and above if you are using Firebase, lower Firebase will not be probably compatible with AdMob since we are using the most updated Admob. According to Admob, Firebase needs to be updated to match the Admob version. And this update will also improve your general SDK integration process for long-term.
+
+**Google Families Policy Edition**
+
+* For games that comply with the Google family policy
+* Ad networks that comply with the Google Families Policy are supported only
+* More information about the Google Family Policy can be found [here](https://support.google.com/googleplay/android-developer/answer/9283445)
 
 ### 2. Integrate the SDK Into Your Project
 Open your Unity project and import the Unity package. Double click the compressed package icon. The files will populate automatically as illustrated below.


### PR DESCRIPTION
Add Google family policy related content to document(integration-unity.md)
1. Add download url
before
Download [Unity Plugin 4.0.1.0](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-4.0.1.0.unitypackage)
after
Download [Unity Plugin 4.0.1.0](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-4.0.1.0.unitypackage) Or Google Families Policy Edition [Unity Plugin 4.0.1.0](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-gp-family-policy-4.0.1.0.unitypackage)

2. Add Google family policy describe

Google Families Policy Edition

* For games that comply with the Google family policy
* Ad networks that comply with the Google Families Policy are supported only
* More information about the Google Family Policy can be found [here](https://support.google.com/googleplay/android-developer/answer/9283445)

View details: https://github.com/Yodo1Games/MAS-Documents/blob/families-policy/markdowns/integration-unity.md#1-download-unity-plugin-4010-or-google-families-policy-edition-unity-plugin-4010

