### PR TITLE
Add "which version of Gradle is required for each version of the Grad…

### DIFF
--- a/markdowns/android-manifest-merging-errors-queries.md
+++ b/markdowns/android-manifest-merging-errors-queries.md
@@ -11,9 +11,10 @@ No special setup required
 
 * Find `File -> Build Setting -> Player Settings -> Publishing Settings -> Build` as shown above in figure 1 and select the options indicated by the arrow
 * Open the `baseProjectTemplate.gradle` file in the `Assets/Plugins/Android/` directory and change `gradle android` version, e.g. 3.4.3
-* Change the version of Gradle used by Unity to match the plugin version modified above, as shown in figure 2
+* Change the version of Gradle used by Unity to match the plugin version modified above, as shown in figure 2, you can view all Gradle versions by clicking [here](https://services.gradle.org/distributions/).
 * Click `Assets -> External Dependency Manager -> Android Resolver -> Force Resolve`
 
+**Note**: To see which version of Gradle is required for each version of the Gradle plugin, please click [here](https://developer.android.com/studio/releases/gradle-plugin#updating-gradle).
 
 ## Unity 2018
 
@@ -23,8 +24,10 @@ No special setup required
 
 * Find`File -> Build Setting -> Player Settings -> Publishing Settings -> Build` as shown above in figure 1 and select the options indicated by the arrow
 * Open the `mainTemplate.gradle` file in the `Assets/Plugins/Android/` directory and change `gradle android` version, e.g. 3.4.3
-* Change the version of Gradle used by Unity to match the plugin version modified above, as shown in figure 2
+* Change the version of Gradle used by Unity to match the plugin version modified above, as shown in figure 2, you can view all Gradle versions by clicking [here](https://services.gradle.org/distributions/).
 * Click `Assets -> External Dependency Manager -> Android Resolver -> Force Resolve`
+
+**Note**: To see which version of Gradle is required for each version of the Gradle plugin, please click [here](https://developer.android.com/studio/releases/gradle-plugin#updating-gradle).
 
 ## Unity 2017
 


### PR DESCRIPTION
android-manifest-merging-errors-queries.md 

Unity 2019 and Unity 2018

1.Change the content as below:
before
Change the version of Gradle used by Unity to match the plugin version modified above, as shown in figure 2
after
Change the version of Gradle used by Unity to match the plugin version modified above, as shown in figure 2, you can view all Gradle versions by clicking [here](https://services.gradle.org/distributions/).

2.Add the content as below:
Note: To see which version of Gradle is required for each version of the Gradle plugin, please click [here](https://developer.android.com/studio/releases/gradle-plugin#updating-gradle).

See this [link](https://github.com/Yodo1Games/MAS-Documents/blob/gradle-content/markdowns/android-manifest-merging-errors-queries.md) for more details
