### PR TITLE
Change SDK version to 4.0.1.2

### DIFF
--- a/markdowns/integration-android.md
+++ b/markdowns/integration-android.md
@@ -23,7 +23,7 @@ maven { url "https://dl.bintray.com/yodo1/android-sdk" }
 ### 2. Open your app-level `build.gradle` and add the relevant code.
 #### 2.1 Add a Gradle dependency
 ```groovy
-implementation 'com.yodo1.mas:standard:4.0.1.0'
+implementation 'com.yodo1.mas:standard:4.0.1.2'
 ```
 
 #### 2.2 Add the `compileOptions` property to the `Android` section

--- a/markdowns/integration-ios.md
+++ b/markdowns/integration-ios.md
@@ -34,7 +34,7 @@ source 'https://github.com/Yodo1Games/MAS-Spec.git'
 source 'https://github.com/Yodo1Games/Yodo1Spec.git'
 
 pod 'FBSDKCoreKit' # If you have introduced FBSDKCoreKit, please ignore
-pod 'Yodo1MasStandard', '~> 4.0.1.0'
+pod 'Yodo1MasStandard', '~> 4.0.1.2'
 ```
 
 Execute the following command in `Terminal` :

--- a/markdowns/integration-unity.md
+++ b/markdowns/integration-unity.md
@@ -10,7 +10,7 @@ If you have not integrated, please read the following documents
 
 ## The Integration Steps
 
-### 1. Download [Unity Plugin 4.0.1.0](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-4.0.1.0.unitypackage) Or Google Families Policy Edition [Unity Plugin 4.0.1.0](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-gp-family-policy-4.0.1.0.unitypackage)
+### 1. Download [Unity Plugin 4.0.1.2](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-4.0.1.2.unitypackage) Or Google Families Policy Edition [Unity Plugin 4.0.1.2](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-gp-family-policy-4.0.1.2.unitypackage)
 > * MAS supports Unity 2017.4.37f1+ LTS version, 2018.4.30f1+ LTS version, 2019.41f18+ LTS version, 2020 all version and above.
 > * [Jetifier](https://developer.android.com/jetpack/androidx/releases/jetifier) is required for Android builds and can be enabled by selecting ***Assets > External Dependency Manager > Android Resolver > Settings > Use Jetifier***
 > * `CocoaPods` is required for iOS builds and can be installed following the instructions [here](https://guides.cocoapods.org/using/getting-started.html#getting-started), please use version 1.8 and above.


### PR DESCRIPTION
integration-android.md 
Before
implementation 'com.yodo1.mas:standard:4.0.1.0'
After
implementation 'com.yodo1.mas:standard:4.0.1.2'

integration-ios.md
Before
pod 'Yodo1MasStandard', '~> 4.0.1.0'
After
pod 'Yodo1MasStandard', '~> 4.0.1.2'

integration-unity.md
Before
Download [Unity Plugin 4.0.1.0](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-4.0.1.0.unitypackage) Or Google Families Policy Edition [Unity Plugin 4.0.1.0](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-gp-family-policy-4.0.1.0.unitypackage)
After
Download [Unity Plugin 4.0.1.2](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-4.0.1.2.unitypackage) Or Google Families Policy Edition [Unity Plugin 4.0.1.2](https://docs.yodo1.com/download/Rivendell-SDKs/Rivendell-gp-family-policy-4.0.1.2.unitypackage)