### PR TITLE
Update 4.0.5 and maven url

### DIFF
--- a/markdowns/app-ads.md
+++ b/markdowns/app-ads.md
@@ -83,7 +83,7 @@ rubiconproject.com, 17328, RESELLER, 0bfd66d529a55807
 adcolony.com, 1efc6603710003ea, RESELLER, 1ad675c9de6b5176
 Contextweb.com, 561884, RESELLER, 89ff185a4c4e857c
 rhythmone.com, 4173858586, RESELLER, a670c89d4a324e47
-improvedig ital.com, 1366, RESELLER
+improvedigital.com, 1366, RESELLER
 EMXDGT.com, 1324, RESELLER, 1e1d41537f7cad7f
 engagebdr.com, 10252, RESELLER #banner #video
 bidmachine.io, 55, RESELLER

--- a/markdowns/app-ads.md
+++ b/markdowns/app-ads.md
@@ -83,7 +83,7 @@ rubiconproject.com, 17328, RESELLER, 0bfd66d529a55807
 adcolony.com, 1efc6603710003ea, RESELLER, 1ad675c9de6b5176
 Contextweb.com, 561884, RESELLER, 89ff185a4c4e857c
 rhythmone.com, 4173858586, RESELLER, a670c89d4a324e47
-improvedigital.com, 1366, RESELLER
+improvedig ital.com, 1366, RESELLER
 EMXDGT.com, 1324, RESELLER, 1e1d41537f7cad7f
 engagebdr.com, 10252, RESELLER #banner #video
 bidmachine.io, 55, RESELLER
@@ -238,6 +238,7 @@ startapp.com, inr, RESELLER
 ucfunnel.com, par-BE7E29B3B48DE66BC7DDDA24E6267E29, RESELLER
 verve.com, 15290, RESELLER, 0c8f5958fc2d6270
 video.unrulymedia.com, 2169000724, RESELLER
+google.com, pub-5784311004955543, DIRECT, f08c47fec0942fa0
 ```
 
 ## 4. When does app-ads.txt get verified? 

--- a/markdowns/integration-android.md
+++ b/markdowns/integration-android.md
@@ -16,9 +16,15 @@ If you have not integrated, please read the following documents
 ```groovy
 maven { url "https://dl.bintray.com/ironsource-mobile/android-sdk" }
 maven { url "https://dl.bintray.com/ironsource-mobile/android-adapters" }
-maven { url "https://dl.bintray.com/mintegral-official/mintegral_ad_sdk_android_for_oversea" }
-maven { url "https://dl.bintray.com/mintegral-official/Andorid_ad_SDK_for_china" }
 maven { url  "https://fyber.bintray.com/marketplace"}
+maven { url "https://dl.bintray.com/yodo1/MAS-Android" }
+maven { url "https://dl.bintray.com/yodo1/android-sdk" }
+```
+
+If you need to comply with Google Family Policy:
+```groovy
+maven { url "https://dl.bintray.com/ironsource-mobile/android-sdk" }
+maven { url "https://dl.bintray.com/ironsource-mobile/android-adapters" }
 maven { url "https://dl.bintray.com/yodo1/MAS-Android" }
 maven { url "https://dl.bintray.com/yodo1/android-sdk" }
 ```
@@ -27,13 +33,13 @@ maven { url "https://dl.bintray.com/yodo1/android-sdk" }
 #### 2.1 Add a Gradle dependency
 
 ```groovy
-implementation 'com.yodo1.mas:full:4.0.4.1'
+implementation 'com.yodo1.mas:full:4.0.5'
 ```
 
 If you need to comply with Google Family Policy:
 
 ```groovy
-implementation 'com.yodo1.mas:google:4.0.4.1'
+implementation 'com.yodo1.mas:google:4.0.5'
 ```
 
 #### 2.2 Add the `compileOptions` property to the `Android` section

--- a/markdowns/integration-unity.md
+++ b/markdowns/integration-unity.md
@@ -10,7 +10,7 @@ If you have not integrated, please read the following documents
 
 ## The Integration Steps
 
-### 1. Download [Unity Plugin 4.0.4](https://docs.yodo1.com/download/Rivendell-SDKs/4.0.4/Rivendell-4.0.4-Full.unitypackage) Or Google Families Policy Edition [Unity Plugin 4.0.4](https://docs.yodo1.com/download/Rivendell-SDKs/4.0.4/Rivendell-4.0.4-Family.unitypackage)
+### 1. Download [Unity Plugin 4.0.5](https://docs.yodo1.com/download/Rivendell-SDKs/4.0.5/Rivendell-4.0.5-Full.unitypackage) Or Google Families Policy Edition [Unity Plugin 4.0.5](https://docs.yodo1.com/download/Rivendell-SDKs/4.0.5/Rivendell-4.0.5-Family.unitypackage)
 > * MAS supports Unity 2017.4.37f1+ LTS version, 2018.4.30f1+ LTS version, 2019.41f18+ LTS version, 2020 all version and above.
 > * [Jetifier](https://developer.android.com/jetpack/androidx/releases/jetifier) is required for Android builds and can be enabled by selecting ***Assets > External Dependency Manager > Android Resolver > Settings > Use Jetifier***
 > * `CocoaPods` is required for iOS builds and can be installed following the instructions [here](https://guides.cocoapods.org/using/getting-started.html#getting-started), please use version 1.8 and above.


### PR DESCRIPTION
1. integration-android.md
* Removed Mintegral maven url, the contents as below:

```
maven { url "https://dl.bintray.com/mintegral-official/mintegral_ad_sdk_android_for_oversea" }
maven { url "https://dl.bintray.com/mintegral-official/Andorid_ad_SDK_for_china" }
```

* Update version to 4.0.5
Before
implementation 'com.yodo1.mas:full:4.0.4.1'
After
implementation 'com.yodo1.mas:full:4.0.5'

2. integration-unity.md
Before
Download [Unity Plugin 4.0.4](https://docs.yodo1.com/download/Rivendell-SDKs/4.0.4/Rivendell-4.0.4-Full.unitypackage) Or Google Families Policy Edition [Unity Plugin 4.0.4](https://docs.yodo1.com/download/Rivendell-SDKs/4.0.4/Rivendell-4.0.4-Family.unitypackage)
After
Download [Unity Plugin 4.0.5](https://docs.yodo1.com/download/Rivendell-SDKs/4.0.5/Rivendell-4.0.5-Full.unitypackage) Or Google Families Policy Edition [Unity Plugin 4.0.5](https://docs.yodo1.com/download/Rivendell-SDKs/4.0.5/Rivendell-4.0.5-Family.unitypackage)

3. app-ads.md
Add new content to app-ads.txt, the content as below:
```
google.com, pub-5784311004955543, DIRECT, f08c47fec0942fa0
```