### PR TITLE
Native Ads & Custom The age verification pop up

### DIFF
--- a/markdowns/integration-android.md
+++ b/markdowns/integration-android.md
@@ -809,6 +809,202 @@ boolean isLoaded = Yodo1Mas.getInstance().isBannerAdLoaded();
 Yodo1Mas.getInstance().showRewardedAd(MyActivity.this);
 ```
 
+## Native Ads Integration
+### 1. Add Yodo1MasNativeAdView to the layout
+
+The first step toward displaying a native is to place `Yodo1MasNativeAdView` in the layout for the Activity or Fragment in which you'd like to display it. The easiest way to do this is to add one to the corresponding XML layout file. Here's an example that shows an activity's `Yodo1MasNativeAdView`:
+
+```xml
+...
+	<com.yodo1.mas.nativeads.Yodo1MasNativeAdView 
+		xmlns:masads="http://schemas.android.com/apk/res-auto"
+		android:id="@+id/yodo1_mas_native"
+		android:layout_width="match_parent"
+		android:layout_height="300dp"
+		android:layout_gravity="center_horizontal|top"/>
+...
+```
+
+You can alternatively create `Yodo1MasNativeAdView` programmatically:
+
+For Java
+
+```java
+Yodo1MasNativeAdView nativeAdView = new Yodo1MasNativeAdView(this);
+nativeAdView.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp2px(300)));
+// TODO: Add nativeAdView to your view hierarchy.
+```
+
+For Kotlin
+
+```kotlin
+val nativeAdView = Yodo1MasNativeAdView(this)
+nativeAdView.setLayoutParams(ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp2px(300)))
+// TODO: Add nativeAdView to your view hierarchy.
+```
+
+### 2. Load an ad
+
+Once the `Yodo1MasNativeAdView` is in place, the next step is to load an ad. That's done with the `loadAd()` method in the `Yodo1MasNativeAdView` class.
+
+Here's an example that shows how to load an ad in the `onCreate()` method of an `Activity`:
+
+For Java
+
+```java
+package ...
+
+import ...
+import com.yodo1.mas.Yodo1Mas;
+import com.yodo1.mas.nativeads.Yodo1MasNativeAdView;
+
+public class MainActivity extends AppCompatActivity {
+    private Yodo1MasNativeAdView nativeAdView;
+
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+
+        Yodo1Mas.getInstance().init(this, "YourAppKey", new Yodo1Mas.InitListener() {
+            @Override
+            public void onMasInitSuccessful() {
+            }
+
+            @Override
+            public void onMasInitFailed(@NonNull Yodo1MasError error) {
+            }
+        });
+
+        nativeAdView = findViewById(R.id.yodo1_mas_native);
+        nativeAdView.loadAd();
+    }
+}
+```
+
+For Kotlin
+
+```kotlin
+package ...
+
+import ...
+import com.yodo1.mas.Yodo1Mas;
+import com.yodo1.mas.nativeads.Yodo1MasNativeAdView;
+
+class MainActivity : AppCompatActivity() {
+
+    lateinit var nativeAdView : Yodo1MasNativeAdView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        Yodo1Mas.getInstance().init(this, "YourAppKey", object : Yodo1Mas.InitListener {
+        	override fun onMasInitSuccessful() {    
+        		Toast.makeText(this@MainActivity, "[Yodo1 Mas] Successful initialization", Toast.LENGTH_SHORT).show()
+        	} 
+        	override fun onMasInitFailed(error: Yodo1MasError) {
+        		Toast.makeText(this@MainActivity, error.message, Toast.LENGTH_SHORT).show()  
+        	}
+        })
+
+        nativeAdView = findViewById(R.id.yodo1_mas_native)
+        nativeAdView.loadAd()
+    }
+}
+```
+
+That's it! Your app is now ready to display native ads.
+
+### 3. Ad events
+
+To further customize the behavior of your ad, you can hook onto a number of events in the ad's lifecycle: loading, opening, closing, and so on. You can listen for these events through the `Yodo1MasNativeAdListener` class.
+
+For Java
+
+```java
+package ...
+
+import ...
+import com.yodo1.mas.Yodo1Mas;
+import com.yodo1.mas.nativeads.Yodo1MasNativeAdListener;
+import com.yodo1.mas.nativeads.Yodo1MasNativeAdView;
+
+public class MainActivity extends AppCompatActivity {
+    private Yodo1MasNativeAdView nativeAdView;
+
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+
+        Yodo1Mas.getInstance().init(this, "YourAppKey", new Yodo1Mas.InitListener() {
+            @Override
+            public void onMasInitSuccessful() {
+            }
+
+            @Override
+            public void onMasInitFailed(@NonNull Yodo1MasError error) {
+            }
+        });
+
+        nativeAdView = findViewById(R.id.yodo1_mas_native);
+        nativeAdView.setAdListener(new Yodo1MasNativeAdListener() {
+		    @Override
+		    public void onNativeAdLoaded(Yodo1MasNativeAdView nativeAdView) {
+		        // Code to be executed when an ad finishes loading.
+		    }
+		
+		    @Override
+		    public void onNativeAdFailedToLoad(Yodo1MasNativeAdView nativeAdView, @NonNull Yodo1MasError error) {
+		        // Code to be executed when an ad request fails.
+		    }
+		 });
+        nativeAdView.loadAd();
+    }
+}
+```
+
+For Kotlin
+
+```kotlin
+package ...
+
+import ...
+import com.yodo1.mas.Yodo1Mas;
+import com.yodo1.mas.nativeads.Yodo1MasNativeAdListener;
+import com.yodo1.mas.nativeads.Yodo1MasNativeAdView;
+
+class MainActivity : AppCompatActivity() {
+
+    lateinit var nativeAdView : Yodo1MasNativeAdView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        Yodo1Mas.getInstance().init(this, "YourAppKey", object : Yodo1Mas.InitListener {
+        	override fun onMasInitSuccessful() {    
+        		Toast.makeText(this@MainActivity, "[Yodo1 Mas] Successful initialization", Toast.LENGTH_SHORT).show()
+        	} 
+        	override fun onMasInitFailed(error: Yodo1MasError) {
+        		Toast.makeText(this@MainActivity, error.message, Toast.LENGTH_SHORT).show()  
+        	}
+        })
+
+        nativeAdView = findViewById(R.id.yodo1_mas_native)
+        nativeAdView.setAdListener(object : Yodo1MasNativeAdListener {
+            override fun onNativeAdLoaded(nativeAdView: Yodo1MasNativeAdView?) {
+                // Code to be executed when an ad finishes loading.
+            }
+
+            override fun onNativeAdFailedToLoad(nativeAdView: Yodo1MasNativeAdView?, error: Yodo1MasError) {
+                // Code to be executed when an ad request fails.
+            }
+        })
+        nativeAdView.loadAd()
+    }
+}
+```
+
 ## Advanced Settings
 ### Ad Placements
 > MAS SDK gives you the ability to set a placement name(e.g. MainMenu, Upgrade_Level etc)

--- a/markdowns/integration-ios.md
+++ b/markdowns/integration-ios.md
@@ -878,7 +878,7 @@ For `Objective-C`
 
 @end
 
-@implementation BannerController
+@implementation MainController
   
 - (void)viewDidLoad {
   [super viewDidLoad];
@@ -944,7 +944,7 @@ For `Objective-C`
 
 @end
 
-@implementation BannerController
+@implementation MainController
   
 - (void)viewDidLoad {
   [super viewDidLoad];
@@ -1112,4 +1112,173 @@ BOOL isLoaded = [[Yodo1Mas sharedInstance] isRewardAdLoaded];
 ### 4. Create a rewarded Placement
 ```obj-c
 [[Yodo1Mas sharedInstance] showRewardAd:@"MY_REWARDED_PLACEMENT"]
+```
+
+## Native Ads Integration
+
+### 1. Init Yodo1MasNativeAdView
+
+For `Objective-C` 
+
+```objective-c
+Yodo1MasNativeAdView *nativeAdView = [[Yodo1MasNativeAdView alloc] init];
+nativeAdView.frame = CGRectMake(0, 0, 375, 200);
+// TODO: Add nativeAdView to your view hierarchy.
+```
+
+For `Swift`
+
+```swift
+let nativeAdView = Yodo1MasNativeAdView()
+bnativeAdView.frame = CGRect(x: 0, y: 0, width: 375, height: 200)
+// TODO: Add bnativeAdView to your view hierarchy.
+```
+### 2. Load an ad
+
+Once the `Yodo1MasNativeAdView` is in place, the next step is to load an ad. That's done with the `loadAd()` method in the `Yodo1MasNativeAdView` class.
+
+Here's an example that shows how to load an ad in the `viewDidLoad` method of an `UIViewController`:
+
+For `Objective-C` 
+
+```objective-c
+
+#import <UIKit/UIKit.h>
+#import "Yodo1Mas.h"
+#import "Yodo1MasNativeAdView.h"
+  
+@interface MainController ()
+  
+@property (nonatomic, strong) Yodo1MasNativeAdView *nativeAdView;
+
+@end
+
+@implementation MainController
+  
+- (void)viewDidLoad {
+  [super viewDidLoad];
+  [[Yodo1Mas sharedInstance] initWithAppKey:@"YourAppKey" successful:^{
+
+  } fail:^(NSError * _Nonnull error) {
+
+  }];
+  
+  _nativeAdView = [[Yodo1MasNativeAdView alloc] init];
+  _nativeAdView.frame = CGRectMake(0, 0, 375, 200);
+  [_nativeAdView loadAd];
+  [self.view addSubview:_nativeAdView];
+}
+@end
+```
+
+For `Swift`
+
+```swift
+import UIKit
+import Yodo1MasCore
+
+class MainController : UIViewController {
+
+	var nativeAdView: Yodo1MasNativeAdView!
+
+	override func viewDidLoad() {
+		super.viewDidLoad()
+    Yodo1Mas.sharedInstance().initWithAppKey("YourAppKey") {
+            
+    } fail: { error in
+
+    }
+    nativeAdView = Yodo1MasNativeAdView()
+    nativeAdView.frame = CGRect(x: 0, y: 0, width: 375, height: 200)
+    nativeAdView.loadAd()
+    self.view.addSubview(nativeAdView)
+   }
+}
+```
+
+That's it! Your app is now ready to display native ads.
+
+### 3. Ad events
+
+To further customize the behavior of your ad, you can hook onto a number of events in the ad's lifecycle: loading, opening, closing, and so on. You can listen for these events through the `Yodo1MasNativeAdViewDelegate`.
+
+For `Objective-C` 
+
+```objective-c
+#import <UIKit/UIKit.h>
+#import "Yodo1Mas.h"
+#import "Yodo1MasNativeAdView.h"
+  
+@interface MainController ()<Yodo1MasNativeAdViewDelegate>
+  
+@property (nonatomic, strong) Yodo1MasNativeAdView *nativeAdView;
+
+@end
+
+@implementation MainController
+  
+- (void)viewDidLoad {
+  [super viewDidLoad];
+  [[Yodo1Mas sharedInstance] initWithAppKey:@"YourAppKey" successful:^{
+
+  } fail:^(NSError * _Nonnull error) {
+
+  }];
+  
+  _nativeAdView = [[Yodo1MasNativeAdView alloc] init];
+  _nativeAdView.frame = CGRectMake(0, 0, 375, 200);
+  _nativeAdView.adDelegate = self;
+  [_nativeAdView loadAd];
+  [self.view addSubview:_nativeAdView];
+}
+
+
+#pragma mark - Yodo1MasNativeAdViewDelegate
+- (void)onNativeAdLoaded:(Yodo1MasNativeAdView *)nativeView {
+    
+}
+
+- (void)onNativeAdFailedToLoad:(Yodo1MasNativeAdView *)nativeView withError:(Yodo1MasError *)error {
+    
+}
+
+@end
+```
+
+For `Swift`
+
+```swift
+import UIKit
+import Yodo1MasCore
+
+class MainController: UIViewController {
+    var nativeAdView: Yodo1MasNativeAdView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        Yodo1Mas.sharedInstance().initWithAppKey("YourAppKey") {
+            
+        } fail: { error in
+            
+        }
+        
+        nativeAdView = Yodo1MasNativeAdView()
+        nativeAdView.frame = CGRect(x: 0, y: 0, width: 375, height: 200)
+        nativeAdView.adDelegate = self
+        nativeAdView.loadAd()
+        self.view.addSubview(nativeAdView)
+    }
+}
+
+extension MainController: Yodo1MasNativeAdViewDelegate {
+    // MARK: Yodo1MasNativeAdViewDelegate
+    func onNativerAdLoaded(_ nativeView: Yodo1MasNativeAdView) {
+        
+    }
+    
+    func onNativeAdFailed(toLoad nativeView: Yodo1MasNativeAdView, withError error: Yodo1MasError) {
+        
+    }
+}
 ```

--- a/markdowns/integration-unity.md
+++ b/markdowns/integration-unity.md
@@ -731,3 +731,128 @@ Simply add the placement name as a string into the parentheses.
 ```c#
 Yodo1U3dMas.ShowRewardedAd("Placement_Name");
 ```
+
+## Native Ads Integration
+
+### 1. Create a Yodo1U3dNativeAdView
+
+The first step toward displaying a native is to create a **Yodo1U3dNativeAdView** object in a C# script attached to a GameObject.
+
+```c#
+using System;
+using UnityEngine;
+using Yodo1.MAS;
+...
+public class NativeSampleV2 : MonoBehaviour
+{
+    private Yodo1U3dNativeAdView nativeAdView;
+    ...
+    public void Start()
+    {
+        // Initialize the MAS SDK.
+        Yodo1U3dMas.SetInitializeDelegate((bool success, Yodo1U3dAdError error) => { });
+        Yodo1U3dMas.InitializeSdk();
+		
+        this.RequestNative();
+    }
+
+    private void RequestNative()
+    {
+        // Create a 320x200 native at top of the screen
+        nativeAdView = new Yodo1U3dNativeAdView(0, 0, 375, 200);
+    }
+}
+```
+
+### 2. Load an ad
+
+Once the NativeView is instantiated, the next step is to load an ad. That's done with the loadAd() method in the NativeView class.
+
+Here's an example that shows how to load an ad:
+
+```c#
+...
+    private void RequestNative()
+    {
+        // Create a 375x200 native at top of the screen
+        nativeAdView = new Yodo1U3dNativeAdView(0, 0, 375, 200);
+
+        // Load native ads, the native ad will be displayed automatically after loaded
+        nativeAdView.LoadAd();
+    }
+...
+```
+
+That's it! Your app is now ready to display native ads from MAS.
+
+### 3. Ad events
+
+To further customize the behavior of your ad, you can hook into a number of events in the ad's lifecycle: loading, opening, closing, and so on.
+
+```c#
+...
+using System;
+using UnityEngine;
+using Yodo1.MAS;
+...
+public class NativeSampleV2 : MonoBehaviour
+{
+    private Yodo1U3dNativeAdView nativeAdView;
+
+    public void Start()
+    {
+        // Initialize the MAS SDK.
+        Yodo1U3dMas.SetInitializeDelegate((bool success, Yodo1U3dAdError error) => { });
+        Yodo1U3dMas.InitializeSdk();
+		
+        this.RequestNative();
+    }
+
+    private void RequestNative()
+    {
+		  // Clean up native before reusing
+        if (nativeAdView != null)
+        {
+            nativeAdView.Destroy();
+        }
+
+    	 // Create a 375x200 native at top of the screen
+        nativeAdView = new Yodo1U3dNativeAdView(0, 0 , 375, 200);
+
+		 // Ad Events
+        nativeAdView.OnAdLoadedEvent += OnNativeAdLoadedEvent;
+        nativeAdView.OnAdFailedToLoadEvent += OnNativeAdFailedToLoadEvent;
+
+        // Load native ads, the native ad will be displayed automatically after loaded
+        nativeAdView.LoadAd();
+    }
+
+    private void OnNativeAdLoadedEvent(Yodo1U3dNativeAdView adView)
+    {
+        // Native ad is ready to be shown.
+        Debug.Log("[Yodo1 Mas] OnNativeAdLoadedEvent event received");
+    }
+
+    private void OnNativeAdFailedToLoadEvent(Yodo1U3dNativeAdView adView, Yodo1U3dAdError adError)
+    {
+        Debug.Log("[Yodo1 Mas] OnNativeAdFailedToLoadEvent event received with error: " + adError.ToString());
+    }
+}
+```
+
+### 5. Clean up native ads
+
+When you are finished with a NativeView, make sure to call the Destroy() method before dropping your reference to it:
+
+```c#
+nativeAdView.Destroy();
+nativeAdView = null;
+```
+
+### 6. Create a Native Placement
+
+Simply add the placement name as a string in the parentheses.
+
+```c#
+nativeAdView.SetAdPlacement("Placement_Name")
+```


### PR DESCRIPTION
# Unity
## Native Ads Integration

### 1. Create a Yodo1U3dNativeAdView

The first step toward displaying a native is to create a **Yodo1U3dNativeAdView** object in a C# script attached to a GameObject.

```c#
using System;
using UnityEngine;
using Yodo1.MAS;
...
public class NativeSampleV2 : MonoBehaviour
{
    private Yodo1U3dNativeAdView nativeAdView;
    ...
    public void Start()
    {
        // Initialize the MAS SDK.
        Yodo1U3dMas.SetInitializeDelegate((bool success, Yodo1U3dAdError error) => { });
        Yodo1U3dMas.InitializeSdk();
		
        this.RequestNative();
    }

    private void RequestNative()
    {
        // Create a 320x200 native at top of the screen
        nativeAdView = new Yodo1U3dNativeAdView(0, 0, 375, 200);
    }
}
```

### 2. Load an ad

Once the NativeView is instantiated, the next step is to load an ad. That's done with the loadAd() method in the NativeView class.

Here's an example that shows how to load an ad:

```c#
...
    private void RequestNative()
    {
        // Create a 375x200 native at top of the screen
        nativeAdView = new Yodo1U3dNativeAdView(0, 0, 375, 200);

        // Load native ads, the native ad will be displayed automatically after loaded
        nativeAdView.LoadAd();
    }
...
```

That's it! Your app is now ready to display native ads from MAS.

### 3. Ad events

To further customize the behavior of your ad, you can hook into a number of events in the ad's lifecycle: loading, opening, closing, and so on.

```c#
...
using System;
using UnityEngine;
using Yodo1.MAS;
...
public class NativeSampleV2 : MonoBehaviour
{
    private Yodo1U3dNativeAdView nativeAdView;

    public void Start()
    {
        // Initialize the MAS SDK.
        Yodo1U3dMas.SetInitializeDelegate((bool success, Yodo1U3dAdError error) => { });
        Yodo1U3dMas.InitializeSdk();
		
        this.RequestNative();
    }

    private void RequestNative()
    {
		  // Clean up native before reusing
        if (nativeAdView != null)
        {
            nativeAdView.Destroy();
        }

    	 // Create a 375x200 native at top of the screen
        nativeAdView = new Yodo1U3dNativeAdView(0, 0 , 375, 200);

		 // Ad Events
        nativeAdView.OnAdLoadedEvent += OnNativeAdLoadedEvent;
        nativeAdView.OnAdFailedToLoadEvent += OnNativeAdFailedToLoadEvent;

        // Load native ads, the native ad will be displayed automatically after loaded
        nativeAdView.LoadAd();
    }

    private void OnNativeAdLoadedEvent(Yodo1U3dNativeAdView adView)
    {
        // Native ad is ready to be shown.
        Debug.Log("[Yodo1 Mas] OnNativeAdLoadedEvent event received");
    }

    private void OnNativeAdFailedToLoadEvent(Yodo1U3dNativeAdView adView, Yodo1U3dAdError adError)
    {
        Debug.Log("[Yodo1 Mas] OnNativeAdFailedToLoadEvent event received with error: " + adError.ToString());
    }
}
```

### 5. Clean up native ads

When you are finished with a NativeView, make sure to call the Destroy() method before dropping your reference to it:

```c#
nativeAdView.Destroy();
nativeAdView = null;
```

### 6. Create a Native Placement

Simply add the placement name as a string in the parentheses.

```c#
nativeAdView.SetAdPlacement("Placement_Name")
```

## Custom The age verification pop up (optional)

```c#
Yodo1MasUserPrivacyConfig userPrivacyConfig = new Yodo1MasUserPrivacyConfig()
    .titleBackgroundColor(Color.green)
    .titleTextColor(Color.blue)
    .contentBackgroundColor(Color.black)
    .contentTextColor(Color.white)
    .buttonBackgroundColor(Color.red)
    .buttonTextColor(Color.green);

Yodo1AdBuildConfig config = new Yodo1AdBuildConfig()
    .enableUserPrivacyDialog(true)
    .userPrivacyConfig(userPrivacyConfig);

Yodo1U3dMas.SetAdBuildConfig(config);
```

# iOS
## Native Ads Integration

### 1. Init Yodo1MasNativeAdView

For `Objective-C` 

```objective-c
Yodo1MasNativeAdView *nativeAdView = [[Yodo1MasNativeAdView alloc] init];
nativeAdView.frame = CGRectMake(0, 0, 375, 200);
// TODO: Add nativeAdView to your view hierarchy.
```

For `Swift`

```swift
let nativeAdView = Yodo1MasNativeAdView()
bnativeAdView.frame = CGRect(x: 0, y: 0, width: 375, height: 200)
// TODO: Add bnativeAdView to your view hierarchy.
```
### 2. Load an ad

Once the `Yodo1MasNativeAdView` is in place, the next step is to load an ad. That's done with the `loadAd()` method in the `Yodo1MasNativeAdView` class.

Here's an example that shows how to load an ad in the `viewDidLoad` method of an `UIViewController`:

For `Objective-C` 

```objective-c

#import <UIKit/UIKit.h>
#import "Yodo1Mas.h"
#import "Yodo1MasNativeAdView.h"
  
@interface MainController ()
  
@property (nonatomic, strong) Yodo1MasNativeAdView *nativeAdView;

@end

@implementation MainController
  
- (void)viewDidLoad {
  [super viewDidLoad];
  [[Yodo1Mas sharedInstance] initWithAppKey:@"YourAppKey" successful:^{

  } fail:^(NSError * _Nonnull error) {

  }];
  
  _nativeAdView = [[Yodo1MasNativeAdView alloc] init];
  _nativeAdView.frame = CGRectMake(0, 0, 375, 200);
  [_nativeAdView loadAd];
  [self.view addSubview:_nativeAdView];
}
@end
```

For `Swift`

```swift
import UIKit
import Yodo1MasCore

class MainController : UIViewController {

	var nativeAdView: Yodo1MasNativeAdView!

	override func viewDidLoad() {
		super.viewDidLoad()
    Yodo1Mas.sharedInstance().initWithAppKey("YourAppKey") {
            
    } fail: { error in

    }
    nativeAdView = Yodo1MasNativeAdView()
    nativeAdView.frame = CGRect(x: 0, y: 0, width: 375, height: 200)
    nativeAdView.loadAd()
    self.view.addSubview(nativeAdView)
   }
}
```

That's it! Your app is now ready to display native ads.

### 3. Ad events

To further customize the behavior of your ad, you can hook onto a number of events in the ad's lifecycle: loading, opening, closing, and so on. You can listen for these events through the `Yodo1MasNativeAdViewDelegate`.

For `Objective-C` 

```objective-c
#import <UIKit/UIKit.h>
#import "Yodo1Mas.h"
#import "Yodo1MasNativeAdView.h"
  
@interface MainController ()<Yodo1MasNativeAdViewDelegate>
  
@property (nonatomic, strong) Yodo1MasNativeAdView *nativeAdView;

@end

@implementation MainController
  
- (void)viewDidLoad {
  [super viewDidLoad];
  [[Yodo1Mas sharedInstance] initWithAppKey:@"YourAppKey" successful:^{

  } fail:^(NSError * _Nonnull error) {

  }];
  
  _nativeAdView = [[Yodo1MasNativeAdView alloc] init];
  _nativeAdView.frame = CGRectMake(0, 0, 375, 200);
  _nativeAdView.adDelegate = self;
  [_nativeAdView loadAd];
  [self.view addSubview:_nativeAdView];
}


#pragma mark - Yodo1MasNativeAdViewDelegate
- (void)onNativeAdLoaded:(Yodo1MasNativeAdView *)nativeView {
    
}

- (void)onNativeAdFailedToLoad:(Yodo1MasNativeAdView *)nativeView withError:(Yodo1MasError *)error {
    
}

@end
```

For `Swift`

```swift
import UIKit
import Yodo1MasCore

class MainController: UIViewController {
    var nativeAdView: Yodo1MasNativeAdView!

    override func viewDidLoad() {
        super.viewDidLoad()
        
        Yodo1Mas.sharedInstance().initWithAppKey("YourAppKey") {
            
        } fail: { error in
            
        }
        
        nativeAdView = Yodo1MasNativeAdView()
        nativeAdView.frame = CGRect(x: 0, y: 0, width: 375, height: 200)
        nativeAdView.adDelegate = self
        nativeAdView.loadAd()
        self.view.addSubview(nativeAdView)
    }
}

extension MainController: Yodo1MasNativeAdViewDelegate {
    // MARK: Yodo1MasNativeAdViewDelegate
    func onNativerAdLoaded(_ nativeView: Yodo1MasNativeAdView) {
        
    }
    
    func onNativeAdFailed(toLoad nativeView: Yodo1MasNativeAdView, withError error: Yodo1MasError) {
        
    }
}
```
## Custom The age verification pop up (optional)

```obj-c
Yodo1MasUserPrivacyConfig *privacyConfig = [Yodo1MasUserPrivacyConfig instance];
privacyConfig.titleBackgroundColor = UIColor.blueColor;
privacyConfig.titleTextColor = UIColor.whiteColor;
privacyConfig.contentBackgroundColor = UIColor.whiteColor;
privacyConfig.contentTextColor = UIColor.darkTextColor;
privacyConfig.buttonBackgroundColor = UIColor.blueColor;
privacyConfig.buttonTextColor = [UIColor whiteColor];
    
Yodo1MasAdBuildConfig *config = [Yodo1MasAdBuildConfig instance];
config.enableUserPrivacyDialog = YES;
config.userPrivacyConfig = privacyConfig;
    
[[Yodo1Mas sharedInstance] setAdBuildConfig:config];
```

# Android
## Native Ads Integration
### 1. Add Yodo1MasNativeAdView to the layout

The first step toward displaying a native is to place `Yodo1MasNativeAdView` in the layout for the Activity or Fragment in which you'd like to display it. The easiest way to do this is to add one to the corresponding XML layout file. Here's an example that shows an activity's `Yodo1MasNativeAdView`:

```xml
...
	<com.yodo1.mas.nativeads.Yodo1MasNativeAdView 
		xmlns:masads="http://schemas.android.com/apk/res-auto"
		android:id="@+id/yodo1_mas_native"
		android:layout_width="match_parent"
		android:layout_height="300dp"
		android:layout_gravity="center_horizontal|top"/>
...
```

You can alternatively create `Yodo1MasNativeAdView` programmatically:

For Java

```java
Yodo1MasNativeAdView nativeAdView = new Yodo1MasNativeAdView(this);
nativeAdView.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp2px(300)));
// TODO: Add nativeAdView to your view hierarchy.
```

For Kotlin

```kotlin
val nativeAdView = Yodo1MasNativeAdView(this)
nativeAdView.setLayoutParams(ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp2px(300)))
// TODO: Add nativeAdView to your view hierarchy.
```

### 2. Load an ad

Once the `Yodo1MasNativeAdView` is in place, the next step is to load an ad. That's done with the `loadAd()` method in the `Yodo1MasNativeAdView` class.

Here's an example that shows how to load an ad in the `onCreate()` method of an `Activity`:

For Java

```java
package ...

import ...
import com.yodo1.mas.Yodo1Mas;
import com.yodo1.mas.nativeads.Yodo1MasNativeAdView;

public class MainActivity extends AppCompatActivity {
    private Yodo1MasNativeAdView nativeAdView;

    protected void onCreate(Bundle savedInstanceState) {
        super.onCreate(savedInstanceState);
        setContentView(R.layout.activity_main);

        Yodo1Mas.getInstance().init(this, "YourAppKey", new Yodo1Mas.InitListener() {
            @Override
            public void onMasInitSuccessful() {
            }

            @Override
            public void onMasInitFailed(@NonNull Yodo1MasError error) {
            }
        });

        nativeAdView = findViewById(R.id.yodo1_mas_native);
        nativeAdView.loadAd();
    }
}
```

For Kotlin

```kotlin
package ...

import ...
import com.yodo1.mas.Yodo1Mas;
import com.yodo1.mas.nativeads.Yodo1MasNativeAdView;

class MainActivity : AppCompatActivity() {

    lateinit var nativeAdView : Yodo1MasNativeAdView

    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        setContentView(R.layout.activity_main)

        Yodo1Mas.getInstance().init(this, "YourAppKey", object : Yodo1Mas.InitListener {
        	override fun onMasInitSuccessful() {    
        		Toast.makeText(this@MainActivity, "[Yodo1 Mas] Successful initialization", Toast.LENGTH_SHORT).show()
        	} 
        	override fun onMasInitFailed(error: Yodo1MasError) {
        		Toast.makeText(this@MainActivity, error.message, Toast.LENGTH_SHORT).show()  
        	}
        })

        nativeAdView = findViewById(R.id.yodo1_mas_native)
        nativeAdView.loadAd()
    }
}
```

That's it! Your app is now ready to display native ads.

### 3. Ad events

To further customize the behavior of your ad, you can hook onto a number of events in the ad's lifecycle: loading, opening, closing, and so on. You can listen for these events through the `Yodo1MasNativeAdListener` class.

For Java

```java
package ...

import ...
import com.yodo1.mas.Yodo1Mas;
import com.yodo1.mas.nativeads.Yodo1MasNativeAdListener;
import com.yodo1.mas.nativeads.Yodo1MasNativeAdView;

public class MainActivity extends AppCompatActivity {
    private Yodo1MasNativeAdView nativeAdView;

    protected void onCreate(Bundle savedInstanceState) {
        super.onCreate(savedInstanceState);
        setContentView(R.layout.activity_main);

        Yodo1Mas.getInstance().init(this, "YourAppKey", new Yodo1Mas.InitListener() {
            @Override
            public void onMasInitSuccessful() {
            }

            @Override
            public void onMasInitFailed(@NonNull Yodo1MasError error) {
            }
        });

        nativeAdView = findViewById(R.id.yodo1_mas_native);
        nativeAdView.setAdListener(new Yodo1MasNativeAdListener() {
		    @Override
		    public void onNativeAdLoaded(Yodo1MasNativeAdView nativeAdView) {
		        // Code to be executed when an ad finishes loading.
		    }
		
		    @Override
		    public void onNativeAdFailedToLoad(Yodo1MasNativeAdView nativeAdView, @NonNull Yodo1MasError error) {
		        // Code to be executed when an ad request fails.
		    }
		 });
        nativeAdView.loadAd();
    }
}
```

For Kotlin

```kotlin
package ...

import ...
import com.yodo1.mas.Yodo1Mas;
import com.yodo1.mas.nativeads.Yodo1MasNativeAdListener;
import com.yodo1.mas.nativeads.Yodo1MasNativeAdView;

class MainActivity : AppCompatActivity() {

    lateinit var nativeAdView : Yodo1MasNativeAdView

    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        setContentView(R.layout.activity_main)

        Yodo1Mas.getInstance().init(this, "YourAppKey", object : Yodo1Mas.InitListener {
        	override fun onMasInitSuccessful() {    
        		Toast.makeText(this@MainActivity, "[Yodo1 Mas] Successful initialization", Toast.LENGTH_SHORT).show()
        	} 
        	override fun onMasInitFailed(error: Yodo1MasError) {
        		Toast.makeText(this@MainActivity, error.message, Toast.LENGTH_SHORT).show()  
        	}
        })

        nativeAdView = findViewById(R.id.yodo1_mas_native)
        nativeAdView.setAdListener(object : Yodo1MasNativeAdListener {
            override fun onNativeAdLoaded(nativeAdView: Yodo1MasNativeAdView?) {
                // Code to be executed when an ad finishes loading.
            }

            override fun onNativeAdFailedToLoad(nativeAdView: Yodo1MasNativeAdView?, error: Yodo1MasError) {
                // Code to be executed when an ad request fails.
            }
        })
        nativeAdView.loadAd()
    }
}
```

## Custom The age verification pop up (optional)

```java
Yodo1MasUserPrivacyConfig agePopBuildConfig = new Yodo1MasUserPrivacyConfig.Builder()
        .titleBackgroundColor(Color.BLUE)
        .titleTextColor(Color.WHITE)
        .contentBackgroundColor(Color.WHITE)
        .contentTextColor(Color.BLACK)
        .buttonBackgroundColor(Color.BLUE)
        .buttonTextColor(Color.WHITE)
        .build();

Yodo1MasAdBuildConfig config = new Yodo1MasAdBuildConfig.Builder()
        .enableUserPrivacyDialog(true)
        .userPrivacyConfig(agePopBuildConfig)
        .build();
Yodo1Mas.getInstance().setAdBuildConfig(config);

```