### PR TITLE
Update versions

### DIFF
--- a/markdowns/integration-android.md
+++ b/markdowns/integration-android.md
@@ -34,19 +34,19 @@ mavenCentral()
 #### 2.1 Add a Gradle dependency
 
 ```groovy
-implementation 'com.yodo1.mas:full:4.6.1'
+implementation 'com.yodo1.mas:full:4.6.2'
 ```
 
 If you need to comply with Google Family Policy:
 
 ```groovy
-implementation 'com.yodo1.mas:google:4.6.1'
+implementation 'com.yodo1.mas:google:4.6.2'
 ```
 
 If you need to use lightweight SDK:
 
 ```groovy
-implementation 'com.yodo1.mas:lite:4.6.1'
+implementation 'com.yodo1.mas:lite:4.6.2'
 ```
 
 #### 2.2 Add the `compileOptions` property to the `Android` section

--- a/markdowns/integration-ios.md
+++ b/markdowns/integration-ios.md
@@ -31,7 +31,7 @@
 	source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
 	source 'https://github.com/Yodo1Games/MAS-Spec.git'
 	
-	pod 'Yodo1MasFull', '4.6.1'
+	pod 'Yodo1MasFull', '4.6.2'
 	```
 
   If you need to use lightweight SDK:
@@ -41,7 +41,7 @@
   source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
   source 'https://github.com/Yodo1Games/MAS-Spec.git'
   
-  pod 'Yodo1MasLite', '4.6.1'
+  pod 'Yodo1MasLite', '4.6.2'
   ```
 	
 	Execute the following command in `Terminal` :
@@ -59,7 +59,7 @@
 
 Follow these steps to add the SDK to your project:
 
-* [Download iOS SDK Version 4.6.1](https://mas-artifacts.yodo1.com/4.6.1/iOS/Release/Yodo1MasFull-Manual-4.6.0-rc.1.zip) or [Download iOS Lite SDK Version 4.6.1](https://mas-artifacts.yodo1.com/4.6.0-rc.1/iOS/Release/Yodo1MasLite-Manual-4.6.1.zip)</br>
+* [Download iOS SDK Version 4.6.2](https://mas-artifacts.yodo1.com/4.6.2/iOS/Release/Yodo1MasFull-Manual-4.6.2.zip) or [Download iOS Lite SDK Version 4.6.2](https://mas-artifacts.yodo1.com/4.6.2/iOS/Release/Yodo1MasLite-Manual-4.6.2.zip)</br>
 	After you download the SDK; Unzip and copy the downloaded SDK into the project
 	<img src="./../resource/ios-manual-01.png" width="400"/>
 	<img src="./../resource/ios-manual-02.png" width="400"/> 

--- a/markdowns/integration-unity.md
+++ b/markdowns/integration-unity.md
@@ -16,11 +16,11 @@ MAS provides 2 versions of the Unity plugin, and you need to select one dependin
 * If your game is not part of the “Designed for Families Program”, please use the Standard MAS Plugin.
 * If your game is a part of Google Play’s “Designed for Families” program, you will need to use the Designed For Families plugin in order to comply with the program’s requirements.
 
-[Designed For Families](https://mas-artifacts.yodo1.com/4.6.1/Unity/Release/Rivendell-4.6.1-Family.unitypackage)
+[Designed For Families](https://mas-artifacts.yodo1.com/4.6.2/Unity/Release/Rivendell-4.6.2-Family.unitypackage)
 
-[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.6.1/Unity/Release/Rivendell-4.6.1-Full.unitypackage)
+[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.6.2/Unity/Release/Rivendell-4.6.2-Full.unitypackage)
 
-[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.6.1/Unity/Release/Rivendell-4.6.1-Lite.unitypackage)
+[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.6.2/Unity/Release/Rivendell-4.6.2-Lite.unitypackage)
 
 ### Note:
 If you are use unity **2018**,please check on the Custom Gradle Template through the following steps:


### PR DESCRIPTION
## Android

Before

```groovy
implementation 'com.yodo1.mas:full:4.6.1'
```

If you need to comply with Google Family Policy:

```groovy
implementation 'com.yodo1.mas:google:4.6.1'
```

If you need to use lightweight SDK:

```groovy
implementation 'com.yodo1.mas:lite:4.6.1'
```

After

```groovy
implementation 'com.yodo1.mas:full:4.6.2'
```

If you need to comply with Google Family Policy:

```groovy
implementation 'com.yodo1.mas:google:4.6.2'
```

If you need to use lightweight SDK:

```groovy
implementation 'com.yodo1.mas:lite:4.6.2'
```

## iOS

Before

`pod 'Yodo1MasFull', '4.6.1'`

`pod 'Yodo1MasLite', '4.6.1'`

After

`pod 'Yodo1MasFull', '4.6.2'`

`pod 'Yodo1MasLite', '4.6.2'`

## Unity

Before

[Designed For Families](https://mas-artifacts.yodo1.com/4.6.1/Unity/Release/Rivendell-4.6.1-Family.unitypackage)

[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.6.1/Unity/Release/Rivendell-4.6.1-Full.unitypackage)

[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.6.1/Unity/Release/Rivendell-4.6.1-Lite.unitypackage)

After 

[Designed For Families](https://mas-artifacts.yodo1.com/4.6.2/Unity/Release/Rivendell-4.6.2-Family.unitypackage)

[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.6.2/Unity/Release/Rivendell-4.6.2-Full.unitypackage)

[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.6.2/Unity/Release/Rivendell-4.6.2-Lite.unitypackage)