### PR TITLE
4.6.4

### DIFF
--- a/markdowns/integration-android.md
+++ b/markdowns/integration-android.md
@@ -34,19 +34,19 @@ mavenCentral()
 #### 2.1 Add a Gradle dependency
 
 ```groovy
-implementation 'com.yodo1.mas:full:4.6.3'
+implementation 'com.yodo1.mas:full:4.6.4'
 ```
 
 If you need to comply with Google Family Policy:
 
 ```groovy
-implementation 'com.yodo1.mas:google:4.6.3'
+implementation 'com.yodo1.mas:google:4.6.4'
 ```
 
 If you need to use lightweight SDK:
 
 ```groovy
-implementation 'com.yodo1.mas:lite:4.6.3'
+implementation 'com.yodo1.mas:lite:4.6.4'
 ```
 
 #### 2.2 Add the `compileOptions` property to the `Android` section

--- a/markdowns/integration-ios.md
+++ b/markdowns/integration-ios.md
@@ -31,7 +31,7 @@
 	source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
 	source 'https://github.com/Yodo1Games/MAS-Spec.git'
 	
-	pod 'Yodo1MasFull', '4.6.3'
+	pod 'Yodo1MasFull', '4.6.4'
 	```
 
   If you need to use lightweight SDK:
@@ -41,7 +41,7 @@
   source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
   source 'https://github.com/Yodo1Games/MAS-Spec.git'
   
-  pod 'Yodo1MasLite', '4.6.3'
+  pod 'Yodo1MasLite', '4.6.4'
   ```
 	
 	Execute the following command in `Terminal` :

--- a/markdowns/integration-unity.md
+++ b/markdowns/integration-unity.md
@@ -16,11 +16,11 @@ MAS provides 2 versions of the Unity plugin, and you need to select one dependin
 * If your game is not part of the “Designed for Families Program”, please use the Standard MAS Plugin.
 * If your game is a part of Google Play’s “Designed for Families” program, you will need to use the Designed For Families plugin in order to comply with the program’s requirements.
 
-[Designed For Families](https://mas-artifacts.yodo1.com/4.6.3/Unity/Release/Rivendell-4.6.3-Family.unitypackage)
+[Designed For Families](https://mas-artifacts.yodo1.com/4.6.4/Unity/Release/Rivendell-4.6.4-Family.unitypackage)
 
-[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.6.3/Unity/Release/Rivendell-4.6.3-Full.unitypackage)
+[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.6.4/Unity/Release/Rivendell-4.6.4-Full.unitypackage)
 
-[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.6.3/Unity/Release/Rivendell-4.6.3-Lite.unitypackage)
+[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.6.4/Unity/Release/Rivendell-4.6.4-Lite.unitypackage)
 
 ### Note:
 If you are use unity **2018**,please check on the Custom Gradle Template through the following steps:


### PR DESCRIPTION
## Unity

Before

[Designed For Families](https://mas-artifacts.yodo1.com/4.6.3/Unity/Release/Rivendell-4.6.3-Family.unitypackage)

[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.6.3/Unity/Release/Rivendell-4.6.3-Full.unitypackage)

[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.6.3/Unity/Release/Rivendell-4.6.3-Lite.unitypackage)

After

[Designed For Families](https://mas-artifacts.yodo1.com/4.6.4/Unity/Release/Rivendell-4.6.4-Family.unitypackage)

[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.6.4/Unity/Release/Rivendell-4.6.4-Full.unitypackage)

[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.6.4/Unity/Release/Rivendell-4.6.4-Lite.unitypackage)

## Android

Before

```groovy
implementation 'com.yodo1.mas:full:4.6.3'
```

If you need to comply with Google Family Policy:

```groovy
implementation 'com.yodo1.mas:google:4.6.3'
```

If you need to use lightweight SDK:

```groovy
implementation 'com.yodo1.mas:lite:4.6.3'
```

After

```groovy
implementation 'com.yodo1.mas:full:4.6.4'
```

If you need to comply with Google Family Policy:

```groovy
implementation 'com.yodo1.mas:google:4.6.4'
```

If you need to use lightweight SDK:

```groovy
implementation 'com.yodo1.mas:lite:4.6.4'
```

## iOS

Before
```
pod 'Yodo1MasFull', '4.6.3'
```
```
pod 'Yodo1MasLite', '4.6.3'
```

After

```
pod 'Yodo1MasFull', '4.6.4'
```
```
pod 'Yodo1MasLite', '4.6.4'
```

### Add Tips

**Tips**
> To ensure your build is compatible with artifacts that contain Swift, set `Build Settings Always Embed Swift Standard Libraries` to `YES`.

> If you use Swift and build for iOS 12.2.0 or earlier, add `/usr/lib/swift` to `Build Settings > Runpath Search Paths` to prevent any issues with `libswiftCore.dylib`.