### PR TITLE
feature：Unity 2018 compile aab file error

### DIFF
--- a/markdowns/known-Issues-unity.md
+++ b/markdowns/known-Issues-unity.md
@@ -7,7 +7,7 @@ Error information: `FileNotFoundException: Temp/gradleOut/launcher/build/utputs/
     <img src="./../resource/known-issues-unity-aaberror.png" width="400"/> 
 </center>
 
-The solution is : At launcherTemplate Of defaultConfig The following code has been added 
+The solution is : Added following code in defaultConfig of launcherTemplate (Unity 2019) or mainTemplate (Unity 2018) 
 
 ```
 tasks.whenTaskAdded {
@@ -19,13 +19,14 @@ tasks.whenTaskAdded {
             def renameTaskName = "rename${task.name.capitalize()}Aab"
             def flavor = task.name.substring("bundle".length()).uncapitalize()
             tasks.create(renameTaskName, Copy) {
-
-
                 def path = "${buildDir}/outputs/bundle/${flavor}/"
                 from(path)
                 include "launcher-release.aab"
                 destinationDir file("${buildDir}/outputs/bundle/${flavor}/")
                 rename "launcher-release.aab", "launcher.aab"
+                include "gradleOut-release.aab"
+                destinationDir file("${buildDir}/outputs/bundle/${flavor}/")
+                rename "gradleOut-release.aab", "gradleOut.aab"
             }
 
             task.finalizedBy(renameTaskName)


### PR DESCRIPTION
## Unity
Before
The solution is : At launcherTemplate Of defaultConfig The following code has been added 

```
tasks.whenTaskAdded {

    task ->
        if (task.name.startsWith("bundle")) {


            def renameTaskName = "rename${task.name.capitalize()}Aab"
            def flavor = task.name.substring("bundle".length()).uncapitalize()
            tasks.create(renameTaskName, Copy) {


                def path = "${buildDir}/outputs/bundle/${flavor}/"
                from(path)
                include "launcher-release.aab"
                destinationDir file("${buildDir}/outputs/bundle/${flavor}/")
                rename "launcher-release.aab", "launcher.aab"
            }

            task.finalizedBy(renameTaskName)
        }
}
```

After
The solution is : Added following code in defaultConfig of launcherTemplate (Unity 2019) or mainTemplate (Unity 2018) 

```
tasks.whenTaskAdded {

    task ->
        if (task.name.startsWith("bundle")) {


            def renameTaskName = "rename${task.name.capitalize()}Aab"
            def flavor = task.name.substring("bundle".length()).uncapitalize()
            tasks.create(renameTaskName, Copy) {
                def path = "${buildDir}/outputs/bundle/${flavor}/"
                from(path)
                include "launcher-release.aab"
                destinationDir file("${buildDir}/outputs/bundle/${flavor}/")
                rename "launcher-release.aab", "launcher.aab"
                include "gradleOut-release.aab"
                destinationDir file("${buildDir}/outputs/bundle/${flavor}/")
                rename "gradleOut-release.aab", "gradleOut.aab"
            }

            task.finalizedBy(renameTaskName)
        }
}
```