### PR TITLE
4.6.6

### DIFF
--- a/markdowns/integration-android.md
+++ b/markdowns/integration-android.md
@@ -34,19 +34,19 @@ mavenCentral()
 #### 2.1 Add a Gradle dependency
 
 ```groovy
-implementation 'com.yodo1.mas:full:4.6.5'
+implementation 'com.yodo1.mas:full:4.6.6'
 ```
 
 If you need to comply with Google Family Policy:
 
 ```groovy
-implementation 'com.yodo1.mas:google:4.6.5'
+implementation 'com.yodo1.mas:google:4.6.6'
 ```
 
 If you need to use lightweight SDK:
 
 ```groovy
-implementation 'com.yodo1.mas:lite:4.6.5'
+implementation 'com.yodo1.mas:lite:4.6.6'
 ```
 
 #### 2.2 Add the `compileOptions` property to the `Android` section

--- a/markdowns/integration-android.md
+++ b/markdowns/integration-android.md
@@ -205,6 +205,14 @@ Yodo1Mas.getInstance().setAdBuildConfig(config);
 
 **IMPORTANT**! Failure to comply with these frameworks can lead to **Google Play Store rejecting** your game, as well as a negative impact of your game’s monetization.
 
+5.Get user age (optional)
+
+```java
+int age = Yodo1Mas.getInstance().getUserAge();
+```
+
+<font color=red>IMPORTANT!</font> `getUserAge()` must be called after the SDK is initialized.
+
 ### 9. Initialize the SDK
 Initialize the SDK in the `onCreate` method of `Activity`
 

--- a/markdowns/integration-ios.md
+++ b/markdowns/integration-ios.md
@@ -806,6 +806,23 @@ config.userPrivacyConfig = privacyConfig;
 
 <font color=red>IMPORTANT!</font> Failure to comply with these frameworks can lead to **Apple App Store and/or Google Play Store rejecting** your game, as well as a negative impact of your game's monetization.
 
+5.Get user age and ATT status (optional)
+
+```obj-c
+NSInteger age = [Yodo1Mas sharedInstance].userAge;
+
+Yodo1MasATTrackingStatus attStatus = [Yodo1Mas sharedInstance].attrackingStatus;
+switch(attStatus) {
+    case Yodo1MasATTrackingStatusNotDetermined: break;
+    case Yodo1MasATTrackingStatusRestricted: break;
+    case Yodo1MasATTrackingStatusDenied: break;
+    case Yodo1MasATTrackingStatusAuthorized: break;
+    case Yodo1MasATTrackingStatusSystemLow: break; // iOS version below 14
+}
+```
+
+<font color=red>IMPORTANT!</font> `userAge` and `attrackingStatus` must be called after the SDK is initialized. 
+
 ### 4. Initialize the SDK
 #### 4.1 Import header file `Yodo1Mas.h`
 ``` obj-c

--- a/markdowns/integration-ios.md
+++ b/markdowns/integration-ios.md
@@ -31,7 +31,7 @@
 	source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
 	source 'https://github.com/Yodo1Games/MAS-Spec.git'
 	
-	pod 'Yodo1MasFull', '4.6.5'
+	pod 'Yodo1MasFull', '4.6.6'
 	```
 
   If you need to use lightweight SDK:
@@ -41,7 +41,7 @@
   source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
   source 'https://github.com/Yodo1Games/MAS-Spec.git'
   
-  pod 'Yodo1MasLite', '4.6.5'
+  pod 'Yodo1MasLite', '4.6.6'
   ```
 	
 	Execute the following command in `Terminal` :

--- a/markdowns/integration-unity.md
+++ b/markdowns/integration-unity.md
@@ -16,11 +16,11 @@ MAS provides 2 versions of the Unity plugin, and you need to select one dependin
 * If your game is not part of the “Designed for Families Program”, please use the Standard MAS Plugin.
 * If your game is a part of Google Play’s “Designed for Families” program, you will need to use the Designed For Families plugin in order to comply with the program’s requirements.
 
-[Designed For Families](https://mas-artifacts.yodo1.com/4.6.5/Unity/Release/Rivendell-4.6.5-Family.unitypackage)
+[Designed For Families](https://mas-artifacts.yodo1.com/4.6.6/Unity/Release/Rivendell-4.6.6-Family.unitypackage)
 
-[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.6.5/Unity/Release/Rivendell-4.6.5-Full.unitypackage)
+[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.6.6/Unity/Release/Rivendell-4.6.6-Full.unitypackage)
 
-[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.6.5/Unity/Release/Rivendell-4.6.5-Lite.unitypackage)
+[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.6.6/Unity/Release/Rivendell-4.6.6-Lite.unitypackage)
 
 ### Note:
 If you are use unity **2018**,please check on the Custom Gradle Template through the following steps:
@@ -157,6 +157,23 @@ Yodo1U3dMas.SetAdBuildConfig(config);
 ```
 
 <font color=red>IMPORTANT!</font> Failure to comply with these frameworks can lead the Apple App Store and/or Google Play Store rejecting your game, as well as a negative impact of your game's monetization.
+
+5.Get user age and ATT status (optional)
+
+```c#
+int age = Yodo1U3dMas.GetUserAge();
+
+int attStatus = Yodo1U3dMas.GetAttrackingStatus();
+switch(attStatus) {
+    case Yodo1U3dAttrackingStatus.NotDetermined: break;
+    case Yodo1U3dAttrackingStatus.Restricted: break;
+    case Yodo1U3dAttrackingStatus.Denied: break;
+    case Yodo1U3dAttrackingStatus.Authorized: break;
+    case Yodo1U3dAttrackingStatus.SystemLow: break;
+}
+```
+
+<font color=red>IMPORTANT!</font> `GetUserAge()` and `GetAttrackingStatus()` must be called after the SDK is initialized. `GetAttrackingStatus()` only works on iOS platform
 
 ### 7. Initialize the SDK
 


### PR DESCRIPTION
## Android

Before
```groovy
implementation 'com.yodo1.mas:full:4.6.5'
```

If you need to comply with Google Family Policy:

```groovy
implementation 'com.yodo1.mas:google:4.6.5'
```

If you need to use lightweight SDK:

```groovy
implementation 'com.yodo1.mas:lite:4.6.5'
```

After

```groovy
implementation 'com.yodo1.mas:full:4.6.6'
```

If you need to comply with Google Family Policy:

```groovy
implementation 'com.yodo1.mas:google:4.6.6'
```

If you need to use lightweight SDK:

```groovy
implementation 'com.yodo1.mas:lite:4.6.6'
```

## iOS

Before

```
pod 'Yodo1MasFull', '4.6.5'
```

```
pod 'Yodo1MasFull', '4.6.5'
```

After

```
pod 'Yodo1MasFull', '4.6.6'
```

```
pod 'Yodo1MasFull', '4.6.6'
```

## Unity

Before

[Designed For Families](https://mas-artifacts.yodo1.com/4.6.5/Unity/Release/Rivendell-4.6.5-Family.unitypackage)

[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.6.5/Unity/Release/Rivendell-4.6.5-Full.unitypackage)

[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.6.5/Unity/Release/Rivendell-4.6.5-Lite.unitypackage)

After

[Designed For Families](https://mas-artifacts.yodo1.com/4.6.6/Unity/Release/Rivendell-4.6.6-Family.unitypackage)

[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.6.6/Unity/Release/Rivendell-4.6.6-Full.unitypackage)

[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.6.6/Unity/Release/Rivendell-4.6.6-Lite.unitypackage)


## Age and ATT status

Please check this PR https://github.com/Yodo1Games/MAS-Documents/pull/58
