### PR TITLE
4.7.5

### DIFF
--- a/markdowns/integration-android.md
+++ b/markdowns/integration-android.md
@@ -1,6 +1,6 @@
 # Android Integration
 
-> MAS supports Android version 4.4.+ (Android API level: 19+) and above
+> MAS supports Android version 5.0.+ (Android API level: 21+) and above
 > 
 > Need compileSdkVersion 31 from MAS SDK 4.6.1
 
@@ -42,19 +42,19 @@ mavenCentral()
 #### 2.1 Add a Gradle dependency
 
 ```groovy
-implementation 'com.yodo1.mas:full:4.7.2'
+implementation 'com.yodo1.mas:full:4.7.5'
 ```
 
 If you need to comply with Google Family Policy:
 
 ```groovy
-implementation 'com.yodo1.mas:google:4.7.2'
+implementation 'com.yodo1.mas:google:4.7.5'
 ```
 
 If you need to use lightweight SDK:
 
 ```groovy
-implementation 'com.yodo1.mas:lite:4.7.2'
+implementation 'com.yodo1.mas:lite:4.7.5'
 ```
 
 #### 2.2 Add the `compileOptions` property to the `Android` section

--- a/markdowns/integration-ios.md
+++ b/markdowns/integration-ios.md
@@ -31,7 +31,7 @@
 	source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
 	source 'https://github.com/Yodo1Games/MAS-Spec.git'
 	
-	pod 'Yodo1MasFull', '4.7.2'
+	pod 'Yodo1MasFull', '4.7.5'
 	```
 
   If you need to use lightweight SDK:
@@ -41,7 +41,7 @@
   source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
   source 'https://github.com/Yodo1Games/MAS-Spec.git'
   
-  pod 'Yodo1MasLite', '4.7.2'
+  pod 'Yodo1MasLite', '4.7.5'
   ```
 	
 	Execute the following command in `Terminal` :

--- a/markdowns/integration-unity.md
+++ b/markdowns/integration-unity.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 * MAS supports Unity LTS versions from 2018 and above
-* To deploy to Android, you need to target API 19+
+* To deploy to Android, you need to target API 21+
 * To deploy to iOS, you need to use Xcode 13+
 * To build on iOS, you need to use Cocoapods 1.10.0+
 * Please make sure to check the Sample `/Assets/Yodo1/MAS/Sample` to aid your integration</br>
@@ -17,11 +17,11 @@ MAS provides 3 versions of the Unity plugin, and you need to select one dependin
 * If your game is not part of the “Designed for Families Program”, please use the Standard SDK.
 * If your game prefers to use the 4 top ad networks to keep the SDK lightweight without making significant compromises on Monetization, please use the Lite SDK.
 
-[Designed For Families](https://mas-artifacts.yodo1.com/4.7.2/Unity/Release/Rivendell-4.7.2-Family.unitypackage)
+[Designed For Families](https://mas-artifacts.yodo1.com/4.7.5/Unity/Release/Rivendell-4.7.5-Family.unitypackage)
 
-[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.7.2/Unity/Release/Rivendell-4.7.2-Full.unitypackage)
+[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.7.5/Unity/Release/Rivendell-4.7.5-Full.unitypackage)
 
-[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.7.2/Unity/Release/Rivendell-4.7.2-Lite.unitypackage)
+[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.7.5/Unity/Release/Rivendell-4.7.5-Lite.unitypackage)
 
 ### Note:
 If you are use unity **2018**,please check on the Custom Gradle Template through the following steps:

--- a/markdowns/questions-android.md
+++ b/markdowns/questions-android.md
@@ -20,7 +20,7 @@ Android has a 64K method constraint. Since the game will include third-party lib
 
 ## What is the minimum Android API version supported by MAS?
 
-MAS SDK supports Android API version 19+.
+MAS SDK supports Android API version 21+.
 
 ## What is the cause of the error below during testing with our demo?
 

--- a/markdowns/supported-engines-minimum-versions.md
+++ b/markdowns/supported-engines-minimum-versions.md
@@ -18,10 +18,10 @@ A plugin for games built on the Unity Engine which will run as mobile apps IOS o
 
 Designed for games and apps that run on an Android-powered mobile phone but were not built from Unity. Any game engine or framework that allows you to build an Android app is eligible to use the Android SDK.  Implemented in Java.
 
-**IMPORTANT!**  MAS supports Android version 4.4.+ (Android API level: 19+).
+**IMPORTANT!**  MAS supports Android version 5.0.+ (Android API level: 21+).
 
 ##  MAS for IOS
 
 Designed for games and apps that run on an iPhone device but were not built from Unity. Any game engine or framework that allows you to build an iPhone app is eligible to use the IOS SDK. Implemented in Objective C.
 
-**IMPORTANT!**  MAS supports iOS 9.0+ and Xcode 12.+.
+**IMPORTANT!**  MAS supports iOS 10.0+ and Xcode 13.+.


### PR DESCRIPTION
## Unity
Before
[Designed For Families](https://mas-artifacts.yodo1.com/4.7.3/Unity/Release/Rivendell-4.7.3-Family.unitypackage)

[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.7.3/Unity/Release/Rivendell-4.7.3-Full.unitypackage)

[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.7.3/Unity/Release/Rivendell-4.7.3-Lite.unitypackage)

After
[Designed For Families](https://mas-artifacts.yodo1.com/4.7.5/Unity/Release/Rivendell-4.7.5-Family.unitypackage)

[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.7.5/Unity/Release/Rivendell-4.7.5-Full.unitypackage)

[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.7.5/Unity/Release/Rivendell-4.7.5-Lite.unitypackage)


Before

* To deploy to Android, you need to target API 19+

After

* To deploy to Android, you need to target API 21+

## Android


Before
```groovy
implementation 'com.yodo1.mas:full:4.7.3'
```

If you need to comply with Google Family Policy:

```groovy
implementation 'com.yodo1.mas:google:4.7.3'
```

If you need to use lightweight SDK:

```groovy
implementation 'com.yodo1.mas:lite:4.7.3'
```

After

```groovy
implementation 'com.yodo1.mas:full:4.7.5'
```

If you need to comply with Google Family Policy:

```groovy
implementation 'com.yodo1.mas:google:4.7.5'
```

If you need to use lightweight SDK:

```groovy
implementation 'com.yodo1.mas:lite:4.7.5'
```
Before

> MAS supports Android version 4.4.+ (Android API level: 19+) and above

After

> MAS supports Android version 5.0.+ (Android API level: 21+) and above


## What is the minimum Android API version supported by MAS?


Before 

MAS SDK supports Android API version 19+.

After

MAS SDK supports Android API version 21+.


## iOS

Before

```
pod 'Yodo1MasFull', '4.7.3'
```

```
pod 'Yodo1MasFull', '4.7.3'
```

After

```
pod 'Yodo1MasFull', '4.7.5'
```

```
pod 'Yodo1MasFull', '4.7.5'
```
