### PR TITLE
4.7.7

### DIFF
--- a/markdowns/integration-android.md
+++ b/markdowns/integration-android.md
@@ -42,19 +42,19 @@ mavenCentral()
 #### 2.1 Add a Gradle dependency
 
 ```groovy
-implementation 'com.yodo1.mas:full:4.7.6'
+implementation 'com.yodo1.mas:full:4.7.7'
 ```
 
 If you need to comply with Google Family Policy:
 
 ```groovy
-implementation 'com.yodo1.mas:google:4.7.6'
+implementation 'com.yodo1.mas:google:4.7.7'
 ```
 
 If you need to use lightweight SDK:
 
 ```groovy
-implementation 'com.yodo1.mas:lite:4.7.6'
+implementation 'com.yodo1.mas:lite:4.7.7'
 ```
 
 #### 2.2 Add the `compileOptions` property to the `Android` section

--- a/markdowns/integration-ios.md
+++ b/markdowns/integration-ios.md
@@ -31,7 +31,7 @@
 	source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
 	source 'https://github.com/Yodo1Games/MAS-Spec.git'
 	
-	pod 'Yodo1MasFull', '4.7.6'
+	pod 'Yodo1MasFull', '4.7.7'
 	```
 
   If you need to use lightweight SDK:
@@ -41,7 +41,7 @@
   source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
   source 'https://github.com/Yodo1Games/MAS-Spec.git'
   
-  pod 'Yodo1MasLite', '4.7.6'
+  pod 'Yodo1MasLite', '4.7.7'
   ```
 	
 	Execute the following command in `Terminal` :

--- a/markdowns/integration-unity.md
+++ b/markdowns/integration-unity.md
@@ -17,11 +17,11 @@ MAS provides 3 versions of the Unity plugin, and you need to select one dependin
 * If your game is not part of the “Designed for Families Program”, please use the Standard SDK.
 * If your game prefers to use the 4 top ad networks to keep the SDK lightweight without making significant compromises on Monetization, please use the Lite SDK.
 
-[Designed For Families](https://mas-artifacts.yodo1.com/4.7.6/Unity/Release/Rivendell-4.7.6-Family.unitypackage)
+[Designed For Families](https://mas-artifacts.yodo1.com/4.7.7/Unity/Release/Rivendell-4.7.7-Family.unitypackage)
 
-[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.7.6/Unity/Release/Rivendell-4.7.6-Full.unitypackage)
+[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.7.7/Unity/Release/Rivendell-4.7.7-Full.unitypackage)
 
-[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.7.6/Unity/Release/Rivendell-4.7.6-Lite.unitypackage)
+[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.7.7/Unity/Release/Rivendell-4.7.7-Lite.unitypackage)
 
 ### Note:
 If you are use unity **2018**,please check on the Custom Gradle Template through the following steps:


### PR DESCRIPTION
## Unity
Before
[Designed For Families](https://mas-artifacts.yodo1.com/4.7.6/Unity/Release/Rivendell-4.7.6-Family.unitypackage)

[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.7.6/Unity/Release/Rivendell-4.7.6-Full.unitypackage)

[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.7.6/Unity/Release/Rivendell-4.7.6-Lite.unitypackage)

After
[Designed For Families](https://mas-artifacts.yodo1.com/4.7.7/Unity/Release/Rivendell-4.7.7-Family.unitypackage)

[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.7.7/Unity/Release/Rivendell-4.7.7-Full.unitypackage)

[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.7.7/Unity/Release/Rivendell-4.7.7-Lite.unitypackage)


## Android


Before
```groovy
implementation 'com.yodo1.mas:full:4.7.6'
```

If you need to comply with Google Family Policy:

```groovy
implementation 'com.yodo1.mas:google:4.7.6'
```

If you need to use lightweight SDK:

```groovy
implementation 'com.yodo1.mas:lite:4.7.6'
```

After

```groovy
implementation 'com.yodo1.mas:full:4.7.7'
```

If you need to comply with Google Family Policy:

```groovy
implementation 'com.yodo1.mas:google:4.7.7'
```

If you need to use lightweight SDK:

```groovy
implementation 'com.yodo1.mas:lite:4.7.7'
```


## iOS

Before

```
pod 'Yodo1MasFull', '4.7.6'
```

```
pod 'Yodo1MasFull', '4.7.6'
```

After

```
pod 'Yodo1MasFull', '4.7.7'
```

```
pod 'Yodo1MasFull', '4.7.7'
```
