### PR TITLE
Release 4.8.1

### DIFF
--- a/markdowns/integration-android.md
+++ b/markdowns/integration-android.md
@@ -822,14 +822,14 @@ For Java
 
 ```java
 Yodo1MasInterstitialAd interstitialAd = Yodo1MasInterstitialAd.getInstance();
-interstitialAd.autoDelayIfLoadFail = true; // if you need
+interstitialAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 ```
 
 For Kotlin
 
 ```kotlin
 val interstitialAd = Yodo1MasInterstitialAd.getInstance()
-interstitialAd.autoDelayIfLoadFail = true; // if you need
+interstitialAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 ```
 
 ### 2. Load an ad
@@ -1087,14 +1087,14 @@ For Java
 
 ```java
 Yodo1MasRewardAd rewardAd = Yodo1MasRewardAd.getInstance();
-rewardAd.autoDelayIfLoadFail = true; // if you need
+rewardAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 ```
 
 For Kotlin
 
 ```kotlin
 val rewardAd = Yodo1MasRewardAd.getInstance()
-rewardAd.autoDelayIfLoadFail = true; // if you need
+rewardAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 ```
 
 ### 2. Load an ad
@@ -1309,14 +1309,14 @@ For Java
 
 ```java
 Yodo1MasRewardedInterstitialAd rewardedInterstitialAd = Yodo1MasRewardedInterstitialAd.getInstance();
-rewardedInterstitialAd.autoDelayIfLoadFail = true; // if you need
+rewardedInterstitialAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 ```
 
 For Kotlin
 
 ```kotlin
 val rewardedInterstitialAd = Yodo1MasRewardedInterstitialAd.getInstance()
-rewardedInterstitialAd.autoDelayIfLoadFail = true; // if you need
+rewardedInterstitialAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 ```
 
 ### 2. Load an ad
@@ -1531,14 +1531,14 @@ For Java
 
 ```java
 Yodo1MasAppOpenAd appOpenAd = Yodo1MasAppOpenAd.getInstance();
-appOpenAd.autoDelayIfLoadFail = true; // if you need
+appOpenAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 ```
 
 For Kotlin
 
 ```kotlin
 val appOpenAd = Yodo1MasAppOpenAd.getInstance()
-appOpenAd.autoDelayIfLoadFail = true; // if you need
+appOpenAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 ```
 
 ### 2. Load an ad

--- a/markdowns/integration-android.md
+++ b/markdowns/integration-android.md
@@ -12,6 +12,7 @@ mavenCentral()
 maven { url "https://artifact.bytedance.com/repository/pangle" }
 maven { url "https://android-sdk.is.com" }
 maven { url "https://sdk.tapjoy.com/" }
+maven { url "https://dl-maven-android.mintegral.com/repository/mbridge_android_sdk_oversea" }
 maven {
     url 'http://maven.aliyun.com/nexus/content/repositories/releases/'
     allowInsecureProtocol = true
@@ -42,19 +43,19 @@ mavenCentral()
 #### 2.1 Add a Gradle dependency
 
 ```groovy
-implementation 'com.yodo1.mas:full:4.8.0'
+implementation 'com.yodo1.mas:full:4.8.1'
 ```
 
 If you need to comply with Google Family Policy:
 
 ```groovy
-implementation 'com.yodo1.mas:google:4.8.0'
+implementation 'com.yodo1.mas:google:4.8.1'
 ```
 
 If you need to use lightweight SDK:
 
 ```groovy
-implementation 'com.yodo1.mas:lite:4.8.0'
+implementation 'com.yodo1.mas:lite:4.8.1'
 ```
 
 #### 2.2 Add the `compileOptions` property to the `Android` section
@@ -821,12 +822,14 @@ For Java
 
 ```java
 Yodo1MasInterstitialAd interstitialAd = Yodo1MasInterstitialAd.getInstance();
+interstitialAd.autoDelayIfLoadFail = true; // if you need
 ```
 
 For Kotlin
 
 ```kotlin
 val interstitialAd = Yodo1MasInterstitialAd.getInstance()
+interstitialAd.autoDelayIfLoadFail = true; // if you need
 ```
 
 ### 2. Load an ad
@@ -860,7 +863,7 @@ public class MainActivity extends AppCompatActivity {
             public void onMasInitFailed(@NonNull Yodo1MasError error) {
             }
         });
-        interstitialAd.loadAd();
+        interstitialAd.loadAd(this);
     }
 }
 ```
@@ -891,7 +894,7 @@ class MainActivity : AppCompatActivity() {
         	}
         })
 
-        interstitialAd.loadAd()
+        interstitialAd.loadAd(this@MainActivity)
     }
 }
 ```
@@ -933,7 +936,7 @@ public class MainActivity extends AppCompatActivity {
 		    @Override
 		    public void onInterstitialAdLoaded(Yodo1MasInterstitialAd ad) {
 		        // Code to be executed when an ad finishes loading.
-                ad.showAd(MainActivity.this);
+                ad.showAd(MainActivity.this, "Your placement id");
 		    }
 		
 		    @Override
@@ -958,7 +961,7 @@ public class MainActivity extends AppCompatActivity {
 		        // to the app after tapping on an ad.
 		    }
 		 });
-        interstitialAd.loadAd();
+        interstitialAd.loadAd(this);
     }
 }
 ```
@@ -993,7 +996,7 @@ class MainActivity : AppCompatActivity() {
         interstitialAd.setAdListener(object : Yodo1MasInterstitialAdListener {
             override fun onInterstitialAdLoaded(ad: Yodo1MasInterstitialAd?) {
                 // Code to be executed when an ad finishes loading.
-                ad.showAd(this@MainActivity)
+                ad.showAd(this@MainActivity, "Your placement id")
             }
 
             override fun onInterstitialAdFailedToLoad(
@@ -1022,7 +1025,7 @@ class MainActivity : AppCompatActivity() {
             }
 
         })
-        interstitialAd.loadAd()
+        interstitialAd.loadAd(this@MainActivity)
     }
 }
 ```
@@ -1084,12 +1087,14 @@ For Java
 
 ```java
 Yodo1MasRewardAd rewardAd = Yodo1MasRewardAd.getInstance();
+rewardAd.autoDelayIfLoadFail = true; // if you need
 ```
 
 For Kotlin
 
 ```kotlin
 val rewardAd = Yodo1MasRewardAd.getInstance()
+rewardAd.autoDelayIfLoadFail = true; // if you need
 ```
 
 ### 2. Load an ad
@@ -1123,7 +1128,7 @@ public class MainActivity extends AppCompatActivity {
             public void onMasInitFailed(@NonNull Yodo1MasError error) {
             }
         });
-        rewardAd.loadAd();
+        rewardAd.loadAd(this);
     }
 }
 ```
@@ -1154,7 +1159,7 @@ class MainActivity : AppCompatActivity() {
         	}
         })
 
-        rewardAd.loadAd()
+        rewardAd.loadAd(this@MainActivity)
     }
 }
 ```
@@ -1196,7 +1201,7 @@ public class MainActivity extends AppCompatActivity {
 		    @Override
 		    public void onRewardAdLoaded(Yodo1MasRewardAd ad) {
 		        // Code to be executed when an ad finishes loading.
-                ad.showAd(MainActivity.this);
+                ad.showAd(MainActivity.this, "Your placement id");
 		    }
 		
 		    @Override
@@ -1226,7 +1231,7 @@ public class MainActivity extends AppCompatActivity {
             
             }
 		 });
-        rewardAd.loadAd();
+        rewardAd.loadAd(this);
     }
 }
 ```
@@ -1261,7 +1266,7 @@ class MainActivity : AppCompatActivity() {
         rewardAd.setAdListener(object : Yodo1MasRewardAdListener {
             override fun onRewardAdLoaded(ad: Yodo1MasRewardAd?) {
                 // Code to be executed when an ad finishes loading.
-                ad.showAd(this@MainActivity)
+                ad.showAd(this@MainActivity, "Your placement id")
             }
 
             override fun onRewardAdFailedToLoad(
@@ -1292,7 +1297,7 @@ class MainActivity : AppCompatActivity() {
                
             }
         })
-        reweardAd.loadAd()
+        reweardAd.loadAd(this@MainActivity)
     }
 }
 ```
@@ -1304,12 +1309,14 @@ For Java
 
 ```java
 Yodo1MasRewardedInterstitialAd rewardedInterstitialAd = Yodo1MasRewardedInterstitialAd.getInstance();
+rewardedInterstitialAd.autoDelayIfLoadFail = true; // if you need
 ```
 
 For Kotlin
 
 ```kotlin
 val rewardedInterstitialAd = Yodo1MasRewardedInterstitialAd.getInstance()
+rewardedInterstitialAd.autoDelayIfLoadFail = true; // if you need
 ```
 
 ### 2. Load an ad
@@ -1343,7 +1350,7 @@ public class MainActivity extends AppCompatActivity {
             public void onMasInitFailed(@NonNull Yodo1MasError error) {
             }
         });
-        rewardedInterstitialAd.loadAd();
+        rewardedInterstitialAd.loadAd(this);
     }
 }
 ```
@@ -1374,7 +1381,7 @@ class MainActivity : AppCompatActivity() {
         	}
         })
 
-        rewardedInterstitialAd.loadAd()
+        rewardedInterstitialAd.loadAd(this@MainActivity)
     }
 }
 ```
@@ -1416,7 +1423,7 @@ public class MainActivity extends AppCompatActivity {
 		    @Override
 		    public void onRewardedInterstitialAdLoaded(Yodo1MasRewardedInterstitialAd ad) {
 		        // Code to be executed when an ad finishes loading.
-                ad.showAd(MainActivity.this);
+                ad.showAd(MainActivity.this, "Your placement id");
 		    }
 		
 		    @Override
@@ -1446,7 +1453,7 @@ public class MainActivity extends AppCompatActivity {
             
             }
 		 });
-        rewardedInterstitialAd.loadAd();
+        rewardedInterstitialAd.loadAd(this);
     }
 }
 ```
@@ -1481,7 +1488,7 @@ class MainActivity : AppCompatActivity() {
         rewardedInterstitialAd.setAdListener(object : Yodo1MasRewardedInterstitialAdListener {
             override fun onRewardedInterstitialAdLoaded(ad: Yodo1MasRewardedInterstitialAd?) {
                 // Code to be executed when an ad finishes loading.
-                ad.showAd(this@MainActivity)
+                ad.showAd(this@MainActivity, "Your placement id")
             }
 
             override fun onRewardedInterstitialAdFailedToLoad(
@@ -1512,7 +1519,7 @@ class MainActivity : AppCompatActivity() {
                
             }
         })
-        rewardedInterstitialAd.loadAd()
+        rewardedInterstitialAd.loadAd(this@MainActivity)
     }
 }
 ```
@@ -1524,12 +1531,14 @@ For Java
 
 ```java
 Yodo1MasAppOpenAd appOpenAd = Yodo1MasAppOpenAd.getInstance();
+appOpenAd.autoDelayIfLoadFail = true; // if you need
 ```
 
 For Kotlin
 
 ```kotlin
 val appOpenAd = Yodo1MasAppOpenAd.getInstance()
+appOpenAd.autoDelayIfLoadFail = true; // if you need
 ```
 
 ### 2. Load an ad
@@ -1563,7 +1572,7 @@ public class MainActivity extends AppCompatActivity {
             public void onMasInitFailed(@NonNull Yodo1MasError error) {
             }
         });
-        appOpenAd.loadAd();
+        appOpenAd.loadAd(this);
     }
 }
 ```
@@ -1594,7 +1603,7 @@ class MainActivity : AppCompatActivity() {
         	}
         })
 
-        appOpenAd.loadAd()
+        appOpenAd.loadAd(this@MainActivity)
     }
 }
 ```
@@ -1636,7 +1645,7 @@ public class MainActivity extends AppCompatActivity {
 		    @Override
 		    public void onAppOpenAdLoaded(Yodo1MasAppOpenAd ad) {
 		        // Code to be executed when an ad finishes loading.
-                ad.showAd(MainActivity.this);
+                ad.showAd(MainActivity.this, "Your placement id");
 		    }
 		
 		    @Override
@@ -1661,7 +1670,7 @@ public class MainActivity extends AppCompatActivity {
 		        // to the app after tapping on an ad.
 		    }
 		 });
-        appOpenAd.loadAd();
+        appOpenAd.loadAd(this);
     }
 }
 ```
@@ -1696,7 +1705,7 @@ class MainActivity : AppCompatActivity() {
         appOpenAd.setAdListener(object : Yodo1MasAppOpenAdListener {
             override fun onAppOpenAdLoaded(ad: Yodo1MasAppOpenAd?) {
                 // Code to be executed when an ad finishes loading.
-                ad.showAd(this@MainActivity)
+                ad.showAd(this@MainActivity, "Your placement id")
             }
 
             override fun onAppOpenAdFailedToLoad(
@@ -1723,7 +1732,7 @@ class MainActivity : AppCompatActivity() {
 		         // to the app after tapping on an ad.
             }
         })
-        appOpenAd.loadAd()
+        appOpenAd.loadAd(this@MainActivity)
     }
 }
 ```
@@ -1787,7 +1796,7 @@ public class MyApplication extends Application implements LifecycleObserver
         Activity activity = Yodo1Mas.getInstance().getCurrentActivity();
         if (activity == null) return;  
         if (appOpenAd.isLoaded()) {
-            appOpenAd.showAd(activity);
+            appOpenAd.showAd(activity, "Your placement id");
         } else {
             appOpenAd.loadAd(activity);
         }
@@ -1854,7 +1863,7 @@ class MyApplication : Application(), LifecycleObserver {
         var activity = Yodo1Mas.getInstance().getCurrentActivity()
         if (activity == null) return 
         if (appOpenAd.isLoaded()) {
-            appOpenAd.showAd(activity)
+            appOpenAd.showAd(activity, "Your placement id")
         } else {
             appOpenAd.loadAd(activity)
         }

--- a/markdowns/integration-ios.md
+++ b/markdowns/integration-ios.md
@@ -31,7 +31,7 @@
 	source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
 	source 'https://github.com/Yodo1Games/MAS-Spec.git'
 	
-	pod 'Yodo1MasFull', '4.8.0'
+	pod 'Yodo1MasFull', '4.8.1'
 	```
 
   If you need to use lightweight SDK:
@@ -41,7 +41,7 @@
   source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
   source 'https://github.com/Yodo1Games/MAS-Spec.git'
   
-  pod 'Yodo1MasLite', '4.8.0'
+  pod 'Yodo1MasLite', '4.8.1'
   ```
 	
 	Execute the following command in `Terminal` :

--- a/markdowns/integration-ios.md
+++ b/markdowns/integration-ios.md
@@ -981,7 +981,7 @@ class MainController : UIViewController {
     }
     bannerAdView = Yodo1MasBannerAdView()
     bannerAdView.setAdSize(.banner)
-    bannerAdView.loadAd()
+    bannerAdView.load()
     let size = bannerAdView.intrinsicContentSize
     bannerAdView.frame = CGRect(x: (self.view.bounds.width - size.width) / 2, y: self.view.bounds.height - size.height, width: size.width, height: size.height)
     self.view.addSubview(bannerAdView)
@@ -1073,7 +1073,7 @@ class MainController: UIViewController {
         bannerAdView = Yodo1MasBannerAdView()
         bannerAdView.setAdSize(.banner)
         bannerAdView.adDelegate = self
-        bannerAdView.loadAd()
+        bannerAdView.load()
         let size = bannerAdView.intrinsicContentSize
         bannerAdView.frame = CGRect(x: (self.view.bounds.width - size.width) / 2, y: self.view.bounds.height - size.height, width: size.width, height: size.height)
         self.view.addSubview(bannerAdView)
@@ -1155,12 +1155,14 @@ For `Objective-C`
 
 ```objective-c
 Yodo1MasInterstitialAd *interstitialAd = [Yodo1MasInterstitialAd sharedInstance];
+interstitialAd.autoDelayIfLoadFail = YES; // if you need
 ```
 
 For `Swift`
 
 ```swift
 let interstitialAd = Yodo1MasInterstitialAd.sharedInstance()
+interstitialAd.autoDelayIfLoadFail = true; // if you need
 ```
 
 ### 2. Load an ad
@@ -1193,7 +1195,6 @@ For `Objective-C`
   }];
   
   _interstitialAd = [Yodo1MasInterstitialAd sharedInstance];
-  [_interstitialAd setAdPlacement:@"Your Placement Id"];
   [_interstitialAd loadAd];
 }
 @end
@@ -1211,14 +1212,13 @@ class MainController : UIViewController {
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
-    Yodo1Mas.sharedInstance().initWithAppKey("YourAppKey") {
-            
-    } fail: { error in
+        Yodo1Mas.sharedInstance().initWithAppKey("YourAppKey") {
+                
+        } fail: { error in
 
-    }
-    interstitialAd = Yodo1MasInterstitialAd.sharedInstance()
-    interstitialAd.setAdPlacement("Your Placement Id")
-    interstitialAd.loadAd()
+        }
+        interstitialAd = Yodo1MasInterstitialAd.sharedInstance()
+        interstitialAd.load()
    }
 }
 ```
@@ -1253,14 +1253,13 @@ For `Objective-C`
   
   _interstitialAd = [Yodo1MasInterstitialAd sharedInstance];
   _interstitialAd.adDelegate = self;
-  [_interstitialAd setAdPlacement:@"Your Placement Id"];
   [_interstitialAd loadAd];
 }
 
 
 #pragma mark - Yodo1MasInterstitialDelegate
 - (void)onInterstitialAdLoaded:(Yodo1MasInterstitialAd *)ad {
-    [ad showAd];
+    [ad showAdWithPlacement:@"Your placement id"];
 }
 
 - (void)onInterstitialAdFailedToLoad:(Yodo1MasInterstitialAd *)ad withError:(Yodo1MasError *)error {
@@ -1301,16 +1300,15 @@ class MainController: UIViewController {
         }
         
         interstitialAd = Yodo1MasInterstitialAd.sharedInstance()
-        interstitialAd.setAdPlacement("Your Placement Id")
         interstitialAd.adDelegate = self
-        interstitialAd.loadAd()
+        interstitialAd.load()
     }
 }
 
 extension MainController: Yodo1MasInterstitialDelegate {
     // MARK: Yodo1MasInterstitialDelegate
     func onInterstitialAdLoaded(_ ad: Yodo1MasInterstitialAd) {
-        ad.showAd()
+        ad.show(withPlacement: "Your placement id")
     }
     
     func onInterstitialAdFailed(toLoad ad: Yodo1MasInterstitialAd, withError error: Yodo1MasError) {
@@ -1386,12 +1384,14 @@ For `Objective-C`
 
 ```objective-c
 Yodo1MasRewardAd *rewardAd = [Yodo1MasRewardAd sharedInstance];
+rewardAd.autoDelayIfLoadFail = YES; // if you need
 ```
 
 For `Swift`
 
 ```swift
 let rewardAd = Yodo1MasRewardAd.sharedInstance()
+rewardAd.autoDelayIfLoadFail = true; // if you need
 ```
 
 ### 2. Load an ad
@@ -1424,7 +1424,6 @@ For `Objective-C`
   }];
   
   _rewardAd = [Yodo1MasRewardAd sharedInstance];
-  [_rewardAd setAdPlacement:@"Your Placement Id"];
   [_rewardAd loadAd];
 }
 @end
@@ -1442,14 +1441,13 @@ class MainController : UIViewController {
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
-    Yodo1Mas.sharedInstance().initWithAppKey("YourAppKey") {
-            
-    } fail: { error in
+        Yodo1Mas.sharedInstance().initWithAppKey("YourAppKey") {
+                
+        } fail: { error in
 
-    }
-    rewardAd = Yodo1MasRewardAd.sharedInstance()
-    rewardAd.setAdPlacement("Your Placement Id")
-    rewardAd.loadAd()
+        }
+        rewardAd = Yodo1MasRewardAd.sharedInstance()
+        rewardAd.load()
    }
 }
 ```
@@ -1484,14 +1482,13 @@ For `Objective-C`
   
   _rewardAd = [Yodo1MasRewardAd sharedInstance];
   _rewardAd.adDelegate = self;
-  [_rewardAd setAdPlacement:@"Your Placement Id"];
   [_rewardAd loadAd];
 }
 
 
 #pragma mark - Yodo1MasRewardDelegate
 - (void)onRewardAdLoaded:(Yodo1MasRewardAd *)ad {
-    [ad showAd];
+    [ad showAdWithPlacement: @"Your placement id"];
 }
 
 - (void)onRewardAdFailedToLoad:(Yodo1MasRewardAd *)ad withError:(Yodo1MasError *)error {
@@ -1536,16 +1533,15 @@ class MainController: UIViewController {
         }
         
         rewardAd = Yodo1MasRewardAd.sharedInstance()
-        rewardAd.setAdPlacement("Your Placement Id")
         rewardAd.adDelegate = self
-        rewardAd.loadAd()
+        rewardAd.load()
     }
 }
 
 extension MainController: Yodo1MasRewardDelegate {
     // MARK: Yodo1MasRewardDelegate
     func onRewardAdLoaded(_ ad: Yodo1MasRewardAd) {
-        ad.showAd()
+        ad.show(withPlacement: "Your placement id")
     }
     
     func onRewardAdFailed(toLoad ad: Yodo1MasRewardAd, withError error: Yodo1MasError) {
@@ -1578,12 +1574,14 @@ For `Objective-C`
 
 ```objective-c
 Yodo1MasRewardedInterstitialAd *rewardedInterstitialAd = [Yodo1MasRewardedInterstitialAd sharedInstance];
+rewardedInterstitialAd.autoDelayIfLoadFail = YES; // if you need
 ```
 
 For `Swift`
 
 ```swift
 let rewardedInterstitialAd = Yodo1MasRewardedInterstitialAd.sharedInstance()
+rewardedInterstitialAd.autoDelayIfLoadFail = true; // if you need
 ```
 
 ### 2. Load an ad
@@ -1616,7 +1614,6 @@ For `Objective-C`
   }];
   
   _rewardedInterstitialAd = [Yodo1MasRewardedInterstitialAd sharedInstance];
-  [_rewardedInterstitialAd setAdPlacement:@"Your Placement Id"];
   [_rewardedInterstitialAd loadAd];
 }
 @end
@@ -1634,14 +1631,13 @@ class MainController : UIViewController {
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
-    Yodo1Mas.sharedInstance().initWithAppKey("YourAppKey") {
-            
-    } fail: { error in
+        Yodo1Mas.sharedInstance().initWithAppKey("YourAppKey") {
+                
+        } fail: { error in
 
-    }
-    rewardedInterstitialAd = Yodo1MasRewardedInterstitialAd.sharedInstance()
-    rewardedInterstitialAd.setAdPlacement("Your Placement Id")
-    rewardedInterstitialAd.loadAd()
+        }
+        rewardedInterstitialAd = Yodo1MasRewardedInterstitialAd.sharedInstance()
+        rewardedInterstitialAd.load()
    }
 }
 ```
@@ -1676,14 +1672,13 @@ For `Objective-C`
   
   _rewardedInterstitialAd = [Yodo1MasRewardedInterstitialAd sharedInstance];
   _rewardedInterstitialAd.adDelegate = self;
-  [_rewardedInterstitialAd setAdPlacement:@"Your Placement Id"];
   [_rewardedInterstitialAd loadAd];
 }
 
 
 #pragma mark - Yodo1MasRewardedInterstitialAdDelegate
 - (void)onRewardedInterstitialAdLoaded:(Yodo1MasRewardedInterstitialAd *)ad {
-    [ad showAd];
+    [ad showAdWithPlacement: @"Your placement id"];
 }
 
 - (void)onRewardedInterstitialAdFailedToLoad:(Yodo1MasRewardedInterstitialAd *)ad withError:(Yodo1MasError *)error {
@@ -1728,16 +1723,15 @@ class MainController: UIViewController {
         }
         
         rewardedInterstitialAd = Yodo1MasRewardedInterstitialAd.sharedInstance()
-        rewardedInterstitialAd.setAdPlacement("Your Placement Id")
         rewardedInterstitialAd.adDelegate = self
-        rewardedInterstitialAd.loadAd()
+        rewardedInterstitialAd.load()
     }
 }
 
 extension MainController: Yodo1MasRewardedInterstitialAdDelegate {
     // MARK: Yodo1MasRewardedInterstitialAdDelegate
     func onRewardedInterstitialAdLoaded(_ ad: Yodo1MasRewardedInterstitialAd) {
-        ad.showAd()
+        ad.show(withPlacement: "Your placement id")
     }
     
     func onRewardedInterstitialAdFailed(toLoad ad: Yodo1MasRewardedInterstitialAd, withError error: Yodo1MasError) {
@@ -1770,12 +1764,14 @@ For `Objective-C`
 
 ```objective-c
 Yodo1MasAppOpenAd *appOpenAd = [Yodo1MasAppOpenAd sharedInstance];
+appOpenAd.autoDelayIfLoadFail = YES; // if you need
 ```
 
 For `Swift`
 
 ```swift
 let appOpenAd = Yodo1MasAppOpenAd.sharedInstance()
+appOpenAd.autoDelayIfLoadFail = true; // if you need
 ```
 
 ### 2. Load an ad
@@ -1808,7 +1804,6 @@ For `Objective-C`
   }];
   
   _appOpenAd = [Yodo1MasAppOpenAd sharedInstance];
-  [_appOpenAd setAdPlacement:@"Your Placement Id"];
   [_appOpenAd loadAd];
 }
 @end
@@ -1826,14 +1821,13 @@ class MainController : UIViewController {
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
-    Yodo1Mas.sharedInstance().initWithAppKey("YourAppKey") {
-            
-    } fail: { error in
+        Yodo1Mas.sharedInstance().initWithAppKey("YourAppKey") {
+                
+        } fail: { error in
 
-    }
-    appOpenAd = Yodo1MasAppOpenAd.sharedInstance()
-    appOpenAd.setAdPlacement("Your Placement Id")
-    appOpenAd.loadAd()
+        }
+        appOpenAd = Yodo1MasAppOpenAd.sharedInstance()
+        appOpenAd.load()
    }
 }
 ```
@@ -1868,14 +1862,13 @@ For `Objective-C`
   
   _appOpenAd = [Yodo1MasAppOpenAd sharedInstance];
   _appOpenAd.adDelegate = self;
-  [_appOpenAd setAdPlacement:@"Your Placement Id"];
   [_appOpenAd loadAd];
 }
 
 
 #pragma mark - Yodo1MasAppOpenAdDelegate
 - (void)onAppOpenAdLoaded:(Yodo1MasAppOpenAd *)ad {
-    [ad showAd];
+    [ad showAdWithPlacement: @"Your placement id"];
 }
 
 - (void)onAppOpenAdFailedToLoad:(Yodo1MasAppOpenAd *)ad withError:(Yodo1MasError *)error {
@@ -1916,16 +1909,15 @@ class MainController: UIViewController {
         }
         
         appOpenAd = Yodo1MasAppOpenAd.sharedInstance()
-        appOpenAd.setAdPlacement("Your Placement Id")
         appOpenAd.adDelegate = self
-        appOpenAd.loadAd()
+        appOpenAd.load()
     }
 }
 
 extension MainController: Yodo1MasAppOpenAdDelegate {
     // MARK: Yodo1MasAppOpenAdDelegate
     func onAppOpenAdLoaded(_ ad: Yodo1MasAppOpenAd) {
-        ad.showAd()
+        ad.show(withPlacement: "Your placement id")
     }
     
     func onAppOpenAdFailed(toLoad ad: Yodo1MasAppOpenAd, withError error: Yodo1MasError) {
@@ -2008,13 +2000,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         appOpenAd = Yodo1MasAppOpenAd.sharedInstance()
         appOpenAd.setAdPlacement("Your Placement Id")
         appOpenAd.adDelegate = self
-        appOpenAd.loadAd()
+        appOpenAd.load()
         return true
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {
         if (appOpenAd.isLoaded) {
-            appOpenAd.showAd();
+            appOpenAd.show();
         }
     }
 }
@@ -2026,7 +2018,7 @@ extension AppDelegate: Yodo1MasAppOpenAdDelegate {
     }
     
     func onAppOpenAdFailed(toLoad ad: Yodo1MasAppOpenAd, withError error: Yodo1MasError) {
-        ad.loadAd()
+        ad.load()
     }
     
     func onAppOpenAdOpened(_ ad: Yodo1MasAppOpenAd) {
@@ -2034,11 +2026,11 @@ extension AppDelegate: Yodo1MasAppOpenAdDelegate {
     }
     
     func onAppOpenAdFailed(toOpen ad: Yodo1MasAppOpenAd, withError error: Yodo1MasError) {
-        ad.loadAd()
+        ad.load()
     }
     
     func onAppOpenAdClosed(_ ad: Yodo1MasAppOpenAd) {
-        ad.loadAd()
+        ad.load()
     }
 }
 ```
@@ -2119,7 +2111,7 @@ class MainController : UIViewController {
     }
     nativeAdView = Yodo1MasNativeAdView()
     nativeAdView.frame = CGRect(x: 0, y: 0, width: 375, height: 200)
-    nativeAdView.loadAd()
+    nativeAdView.load()
     self.view.addSubview(nativeAdView)
    }
 }
@@ -2195,7 +2187,7 @@ class MainController: UIViewController {
         nativeAdView = Yodo1MasNativeAdView()
         nativeAdView.frame = CGRect(x: 0, y: 0, width: 375, height: 200)
         nativeAdView.adDelegate = self
-        nativeAdView.loadAd()
+        nativeAdView.load()
         self.view.addSubview(nativeAdView)
     }
 }
@@ -2438,7 +2430,7 @@ class MainController : UIViewController {
     nativeView.setLayoutXib("NativeCustomAdView", builder:builder)
     //nativeView.setLayout(NativeCustomAdView.self, builder:builder)
 
-    nativeAdView.loadAd()
+    nativeAdView.load()
     self.view.addSubview(nativeAdView)
    }
 }
@@ -2514,7 +2506,7 @@ class MainController: UIViewController {
         nativeAdView = Yodo1MasNativeAdView()
         nativeAdView.frame = CGRect(x: 0, y: 0, width: 375, height: 200)
         nativeAdView.adDelegate = self
-        nativeAdView.loadAd()
+        nativeAdView.load()
         self.view.addSubview(nativeAdView)
     }
 }

--- a/markdowns/integration-ios.md
+++ b/markdowns/integration-ios.md
@@ -1155,14 +1155,14 @@ For `Objective-C`
 
 ```objective-c
 Yodo1MasInterstitialAd *interstitialAd = [Yodo1MasInterstitialAd sharedInstance];
-interstitialAd.autoDelayIfLoadFail = YES; // if you need
+interstitialAd.autoDelayIfLoadFail = YES; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 ```
 
 For `Swift`
 
 ```swift
 let interstitialAd = Yodo1MasInterstitialAd.sharedInstance()
-interstitialAd.autoDelayIfLoadFail = true; // if you need
+interstitialAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 ```
 
 ### 2. Load an ad
@@ -1384,14 +1384,14 @@ For `Objective-C`
 
 ```objective-c
 Yodo1MasRewardAd *rewardAd = [Yodo1MasRewardAd sharedInstance];
-rewardAd.autoDelayIfLoadFail = YES; // if you need
+rewardAd.autoDelayIfLoadFail = YES; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 ```
 
 For `Swift`
 
 ```swift
 let rewardAd = Yodo1MasRewardAd.sharedInstance()
-rewardAd.autoDelayIfLoadFail = true; // if you need
+rewardAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 ```
 
 ### 2. Load an ad
@@ -1574,14 +1574,14 @@ For `Objective-C`
 
 ```objective-c
 Yodo1MasRewardedInterstitialAd *rewardedInterstitialAd = [Yodo1MasRewardedInterstitialAd sharedInstance];
-rewardedInterstitialAd.autoDelayIfLoadFail = YES; // if you need
+rewardedInterstitialAd.autoDelayIfLoadFail = YES; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 ```
 
 For `Swift`
 
 ```swift
 let rewardedInterstitialAd = Yodo1MasRewardedInterstitialAd.sharedInstance()
-rewardedInterstitialAd.autoDelayIfLoadFail = true; // if you need
+rewardedInterstitialAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 ```
 
 ### 2. Load an ad
@@ -1764,14 +1764,14 @@ For `Objective-C`
 
 ```objective-c
 Yodo1MasAppOpenAd *appOpenAd = [Yodo1MasAppOpenAd sharedInstance];
-appOpenAd.autoDelayIfLoadFail = YES; // if you need
+appOpenAd.autoDelayIfLoadFail = YES; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 ```
 
 For `Swift`
 
 ```swift
 let appOpenAd = Yodo1MasAppOpenAd.sharedInstance()
-appOpenAd.autoDelayIfLoadFail = true; // if you need
+appOpenAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 ```
 
 ### 2. Load an ad

--- a/markdowns/integration-ios.md
+++ b/markdowns/integration-ios.md
@@ -219,11 +219,243 @@ The following shows the array of dictionaries you need to access the SDK.
 ```
 <dict>
     <key>SKAdNetworkIdentifier</key>
+    <string>275upjj5gd.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>294l99pt4k.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
     <string>2fnua5tdw4.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
     <string>2u9pt9hc89.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>3rd42ekr43.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>4468km3ulz.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>44jx6755aq.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>44n7hlldy6.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>4fzdc2evr5.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>4pfyvq9l8r.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>523jb4fst2.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>578prtvx9j.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>5l3tpt7t6e.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>5lm9lj6jb7.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>6964rsfnh4.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>6g9af3uyq4.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>74b6s63p6l.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>7rz58n8ntl.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>7ug5zh24hu.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>84993kbrcf.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>8s468mfl3y.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>9nlqeag3gk.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>9rd848q2bz.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>9t245vhmpl.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>a7xqa6mtl2.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>c3frkrj4fj.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>c6k4g5qg8m.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>cg4yq2srnc.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>cj5566h2ga.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>e5fvkxwrpn.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>ejvt5qm6ak.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>g28c52eehv.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>g2y4y55b64.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>gta9lk7p23.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>hs6bdukanm.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>kbd757ywx3.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>kbmxgpxpgc.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>klf5c3l5u5.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>m8dbw4sv7c.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>mlmmfzh3r3.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>mtkv5xtk9e.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>n6fk4nfna4.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>n9x2a789qt.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>ppxm28t8ap.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>prcb7njmu6.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>pwa73g5rt2.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>pwdxu55a5a.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>qqp299437r.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>r45fhb6rf7.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>rx5hdcabgc.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>t38b2kh725.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>tl55sbb4fm.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>u679fj5vs4.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>uw77j35x4d.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>v72qych5uu.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>wg4vff78zm.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>wzmmz9fp6w.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>yclnxrl5pm.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>ydx93a7ass.skadnetwork</string>
+</dict>
+<dict>
+    <key>SKAdNetworkIdentifier</key>
+    <string>22mmun2rn5.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -243,7 +475,7 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>4468km3ulz.skadnetwork</string>
+    <string>47vhws6wlr.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -251,19 +483,7 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>4fzdc2evr5.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>578prtvx9j.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
     <string>5a6flpkh64.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>7ug5zh24hu.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -271,15 +491,7 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>8s468mfl3y.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>9rd848q2bz.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>9t245vhmpl.skadnetwork</string>
+    <string>a2p9lx4jpn.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -287,7 +499,7 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>c6k4g5qg8m.skadnetwork</string>
+    <string>cp8zw746q7.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -295,7 +507,7 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>e5fvkxwrpn.skadnetwork</string>
+    <string>ecpz2srf59.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -303,19 +515,11 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>hs6bdukanm.skadnetwork</string>
+    <string>ludvb6z3bs.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>kbd757ywx3.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>klf5c3l5u5.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>n6fk4nfna4.skadnetwork</string>
+    <string>n38lu8286q.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -323,23 +527,7 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>ppxm28t8ap.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>prcb7njmu6.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
     <string>s39g8k73mm.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>t38b2kh725.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>uw77j35x4d.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -347,19 +535,11 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>v72qych5uu.skadnetwork</string>
+    <string>v9wttpbfk9.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>wzmmz9fp6w.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>yclnxrl5pm.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>ydx93a7ass.skadnetwork</string>
+    <string>y5ghdn5j9k.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -367,19 +547,7 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>22mmun2rn5.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
     <string>24t9a8vw3c.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>275upjj5gd.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>294l99pt4k.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -391,18 +559,6 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>3rd42ekr43.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>4pfyvq9l8r.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>523jb4fst2.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
     <string>52fl2v3hgk.skadnetwork</string>
 </dict>
 <dict>
@@ -411,19 +567,7 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>5l3tpt7t6e.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>5lm9lj6jb7.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
     <string>5tjdwbrq8w.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>6g9af3uyq4.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -435,15 +579,7 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>7rz58n8ntl.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
     <string>9b89h5y424.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>9nlqeag3gk.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -455,31 +591,11 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>c3frkrj4fj.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>cg4yq2srnc.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>cj5566h2ga.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
     <string>dkc879ngq3.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>ejvt5qm6ak.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
     <string>feyaarzu9v.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>g28c52eehv.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -491,19 +607,7 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>gta9lk7p23.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
     <string>k674qkevps.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>kbmxgpxpgc.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>ludvb6z3bs.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -511,23 +615,7 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>m8dbw4sv7c.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>mlmmfzh3r3.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>mtkv5xtk9e.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
     <string>n66cz3y3bx.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>n9x2a789qt.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -535,31 +623,11 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>pwa73g5rt2.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>qqp299437r.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>r45fhb6rf7.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
     <string>rvh3l7un93.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>tl55sbb4fm.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
     <string>vcra2ehyfk.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>wg4vff78zm.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -587,19 +655,7 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>n38lu8286q.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>v9wttpbfk9.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
     <string>252b5q8x7y.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>44jx6755aq.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -623,15 +679,7 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>rx5hdcabgc.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
     <string>y45688jllp.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>74b6s63p6l.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -655,7 +703,7 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>r26jy69rpl.skadnetwork</string>
+    <string>737z793b9f.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -663,23 +711,7 @@ The following shows the array of dictionaries you need to access the SDK.
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
-    <string>44n7hlldy6.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
     <string>488r3q3dtq.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>737z793b9f.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>a2p9lx4jpn.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>ecpz2srf59.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>
@@ -692,10 +724,6 @@ The following shows the array of dictionaries you need to access the SDK.
 <dict>
     <key>SKAdNetworkIdentifier</key>
     <string>pu4na253f3.skadnetwork</string>
-</dict>
-<dict>
-    <key>SKAdNetworkIdentifier</key>
-    <string>u679fj5vs4.skadnetwork</string>
 </dict>
 <dict>
     <key>SKAdNetworkIdentifier</key>

--- a/markdowns/integration-unity.md
+++ b/markdowns/integration-unity.md
@@ -757,6 +757,7 @@ public class InterstitialSampleV2 : MonoBehaviour
     private void RequestInterstitial()
     {
         interstitialAd = Yodo1U3dInterstitialAd.GetInstance();
+        interstitialAd.autoDelayIfLoadFail = true;
     }
 }
 ```
@@ -772,6 +773,7 @@ Here's an example that shows how to load an ad:
     private void RequestInterstitial()
     {
         interstitialAd = Yodo1U3dInterstitialAd.GetInstance();
+        interstitialAd.autoDelayIfLoadFail = true;
         interstitialAd.LoadAd();
     }
 ...
@@ -805,6 +807,7 @@ public class InterstitialSampleV2 : MonoBehaviour
     private void RequestInterstitial()
     {
         interstitialAd = Yodo1U3dInterstitialAd.GetInstance();
+        interstitialAd.autoDelayIfLoadFail = true;
 
 		 // Ad Events
         interstitialAd.OnAdLoadedEvent += OnInterstitialAdLoadedEvent;
@@ -943,6 +946,7 @@ public class RewardSampleV2 : MonoBehaviour
     private void RequestReward()
     {
         rewardAd = Yodo1U3dRewardAd.GetInstance();
+        rewardAd.autoDelayIfLoadFail = true;
     }
 }
 ```
@@ -958,6 +962,7 @@ Here's an example that shows how to load an ad:
     private void RequestReward()
     {
         rewardAd = Yodo1U3dRewardAd.GetInstance();
+        rewardAd.autoDelayIfLoadFail = true;
         rewardAd.LoadAd();
     }
 ...
@@ -991,6 +996,7 @@ public class RewardSampleV2 : MonoBehaviour
     private void RequestReward()
     {
         rewardAd = Yodo1U3dRewardAd.GetInstance();
+        rewardAd.autoDelayIfLoadFail = true;
 
 		 // Ad Events
         rewardAd.OnAdLoadedEvent += OnRewardAdLoadedEvent;
@@ -1070,6 +1076,7 @@ public class RewardedInterstitialSampleV2 : MonoBehaviour
     private void RequestRewardedInterstitial()
     {
         rewardedInterstitialAd = Yodo1U3dRewardedInterstitialAd.GetInstance();
+        rewardedInterstitialAd.autoDelayIfLoadFail = true;
     }
 }
 ```
@@ -1085,6 +1092,7 @@ Here's an example that shows how to load an ad:
     private void RequestRewardedInterstitial()
     {
         rewardedInterstitialAd = Yodo1U3dRewardedInterstitialAd.GetInstance();
+        rewardedInterstitialAd.autoDelayIfLoadFail = true;
         rewardedInterstitialAd.LoadAd();
     }
 ...
@@ -1118,6 +1126,7 @@ public class RewardedInterstitialSampleV2 : MonoBehaviour
     private void RequestRewardedInterstitial()
     {
         rewardedInterstitialAd = Yodo1U3dRewardedInterstitialAd.GetInstance();
+        rewardedInterstitialAd.autoDelayIfLoadFail = true;
 
 		 // Ad Events
         rewardedInterstitialAd.OnAdLoadedEvent += OnRewardedInterstitialAdLoadedEvent;
@@ -1198,6 +1207,7 @@ public class AppOpenSampleV2 : MonoBehaviour
     private void RequestAppOpen()
     {
         appOpenAd = Yodo1U3dAppOpenAd.GetInstance();
+        appOpenAd.autoDelayIfLoadFail = true;
     }
 }
 ```
@@ -1213,6 +1223,7 @@ Here's an example that shows how to load an ad:
     private void RequestAppOpen()
     {
         appOpenAd = Yodo1U3dAppOpenAd.GetInstance();
+        appOpenAd.autoDelayIfLoadFail = true;
         appOpenAd.LoadAd();
     }
 ...
@@ -1246,6 +1257,7 @@ public class AppOpenSampleV2 : MonoBehaviour
     private void RequestAppOpen()
     {
         appOpenAd = Yodo1U3dAppOpenAd.GetInstance();
+        appOpenAd.autoDelayIfLoadFail = true;
 
 		 // Ad Events
         appOpenAd.OnAdLoadedEvent += OnAppOpenAdLoadedEvent;
@@ -1315,6 +1327,8 @@ public class AppOpenSampleV2 : MonoBehaviour
     private void RequestAppOpen()
     {
         appOpenAd = Yodo1U3dAppOpenAd.GetInstance();
+        appOpenAd.autoDelayIfLoadFail = true;
+        
         appOpenAd.OnAdLoadedEvent += OnAppOpenAdLoadedEvent;
         appOpenAd.OnAdLoadFailedEvent += OnAppOpenAdLoadFailedEvent;
         appOpenAd.OnAdOpenedEvent += OnAppOpenAdOpenedEvent;

--- a/markdowns/integration-unity.md
+++ b/markdowns/integration-unity.md
@@ -757,7 +757,7 @@ public class InterstitialSampleV2 : MonoBehaviour
     private void RequestInterstitial()
     {
         interstitialAd = Yodo1U3dInterstitialAd.GetInstance();
-        interstitialAd.autoDelayIfLoadFail = true;
+        interstitialAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
     }
 }
 ```
@@ -773,7 +773,7 @@ Here's an example that shows how to load an ad:
     private void RequestInterstitial()
     {
         interstitialAd = Yodo1U3dInterstitialAd.GetInstance();
-        interstitialAd.autoDelayIfLoadFail = true;
+        interstitialAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
         interstitialAd.LoadAd();
     }
 ...
@@ -807,7 +807,7 @@ public class InterstitialSampleV2 : MonoBehaviour
     private void RequestInterstitial()
     {
         interstitialAd = Yodo1U3dInterstitialAd.GetInstance();
-        interstitialAd.autoDelayIfLoadFail = true;
+        interstitialAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 
 		 // Ad Events
         interstitialAd.OnAdLoadedEvent += OnInterstitialAdLoadedEvent;
@@ -946,7 +946,7 @@ public class RewardSampleV2 : MonoBehaviour
     private void RequestReward()
     {
         rewardAd = Yodo1U3dRewardAd.GetInstance();
-        rewardAd.autoDelayIfLoadFail = true;
+        rewardAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
     }
 }
 ```
@@ -962,7 +962,7 @@ Here's an example that shows how to load an ad:
     private void RequestReward()
     {
         rewardAd = Yodo1U3dRewardAd.GetInstance();
-        rewardAd.autoDelayIfLoadFail = true;
+        rewardAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
         rewardAd.LoadAd();
     }
 ...
@@ -996,7 +996,7 @@ public class RewardSampleV2 : MonoBehaviour
     private void RequestReward()
     {
         rewardAd = Yodo1U3dRewardAd.GetInstance();
-        rewardAd.autoDelayIfLoadFail = true;
+        rewardAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 
 		 // Ad Events
         rewardAd.OnAdLoadedEvent += OnRewardAdLoadedEvent;
@@ -1076,7 +1076,7 @@ public class RewardedInterstitialSampleV2 : MonoBehaviour
     private void RequestRewardedInterstitial()
     {
         rewardedInterstitialAd = Yodo1U3dRewardedInterstitialAd.GetInstance();
-        rewardedInterstitialAd.autoDelayIfLoadFail = true;
+        rewardedInterstitialAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
     }
 }
 ```
@@ -1092,7 +1092,7 @@ Here's an example that shows how to load an ad:
     private void RequestRewardedInterstitial()
     {
         rewardedInterstitialAd = Yodo1U3dRewardedInterstitialAd.GetInstance();
-        rewardedInterstitialAd.autoDelayIfLoadFail = true;
+        rewardedInterstitialAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
         rewardedInterstitialAd.LoadAd();
     }
 ...
@@ -1126,7 +1126,7 @@ public class RewardedInterstitialSampleV2 : MonoBehaviour
     private void RequestRewardedInterstitial()
     {
         rewardedInterstitialAd = Yodo1U3dRewardedInterstitialAd.GetInstance();
-        rewardedInterstitialAd.autoDelayIfLoadFail = true;
+        rewardedInterstitialAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 
 		 // Ad Events
         rewardedInterstitialAd.OnAdLoadedEvent += OnRewardedInterstitialAdLoadedEvent;
@@ -1207,7 +1207,7 @@ public class AppOpenSampleV2 : MonoBehaviour
     private void RequestAppOpen()
     {
         appOpenAd = Yodo1U3dAppOpenAd.GetInstance();
-        appOpenAd.autoDelayIfLoadFail = true;
+        appOpenAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
     }
 }
 ```
@@ -1223,7 +1223,7 @@ Here's an example that shows how to load an ad:
     private void RequestAppOpen()
     {
         appOpenAd = Yodo1U3dAppOpenAd.GetInstance();
-        appOpenAd.autoDelayIfLoadFail = true;
+        appOpenAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
         appOpenAd.LoadAd();
     }
 ...
@@ -1257,7 +1257,7 @@ public class AppOpenSampleV2 : MonoBehaviour
     private void RequestAppOpen()
     {
         appOpenAd = Yodo1U3dAppOpenAd.GetInstance();
-        appOpenAd.autoDelayIfLoadFail = true;
+        appOpenAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
 
 		 // Ad Events
         appOpenAd.OnAdLoadedEvent += OnAppOpenAdLoadedEvent;
@@ -1327,7 +1327,7 @@ public class AppOpenSampleV2 : MonoBehaviour
     private void RequestAppOpen()
     {
         appOpenAd = Yodo1U3dAppOpenAd.GetInstance();
-        appOpenAd.autoDelayIfLoadFail = true;
+        appOpenAd.autoDelayIfLoadFail = true; // If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
         
         appOpenAd.OnAdLoadedEvent += OnAppOpenAdLoadedEvent;
         appOpenAd.OnAdLoadFailedEvent += OnAppOpenAdLoadFailedEvent;

--- a/markdowns/integration-unity.md
+++ b/markdowns/integration-unity.md
@@ -17,11 +17,11 @@ MAS provides 3 versions of the Unity plugin, and you need to select one dependin
 * If your game is not part of the “Designed for Families Program”, please use the Standard SDK.
 * If your game prefers to use the 4 top ad networks to keep the SDK lightweight without making significant compromises on Monetization, please use the Lite SDK.
 
-[Designed For Families](https://mas-artifacts.yodo1.com/4.8.0/Unity/Release/Rivendell-4.8.0-Family.unitypackage)
+[Designed For Families](https://mas-artifacts.yodo1.com/4.8.1/Unity/Release/Rivendell-4.8.1-Family.unitypackage)
 
-[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.8.0/Unity/Release/Rivendell-4.8.0-Full.unitypackage)
+[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.8.1/Unity/Release/Rivendell-4.8.1-Full.unitypackage)
 
-[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.8.0/Unity/Release/Rivendell-4.8.0-Lite.unitypackage)
+[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.8.1/Unity/Release/Rivendell-4.8.1-Lite.unitypackage)
 
 ### Note:
 If you are use unity **2018**,please check on the Custom Gradle Template through the following steps:


### PR DESCRIPTION
## Unity

Before

[Designed For Families](https://mas-artifacts.yodo1.com/4.8.0/Unity/Release/Rivendell-4.8.0-Family.unitypackage)
[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.8.0/Unity/Release/Rivendell-4.8.0-Full.unitypackage)
[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.8.0/Unity/Release/Rivendell-4.8.0-Lite.unitypackage)

After

[Designed For Families](https://mas-artifacts.yodo1.com/4.8.1/Unity/Release/Rivendell-4.8.1-Family.unitypackage)
[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.8.1/Unity/Release/Rivendell-4.8.1-Full.unitypackage)
[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.8.1/Unity/Release/Rivendell-4.8.1-Lite.unitypackage)


```c#
// If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
// Turn on delay if autoDelayIfLoadFail = true
Yodo1U3dInterstitialAd.GetInstance().autoDelayIfLoadFail = true;
Yodo1U3dRewardAd.GetInstance().autoDelayIfLoadFail = true;
Yodo1U3dAppOpenAd.GetInstance().autoDelayIfLoadFail = true;
Yodo1U3dRewardedInterstitialAd.GetInstance().autoDelayIfLoadFail = true;
```

## Android

#### 1. Open your project-level `build.gradle` and add the relevant code.

```groovy
mavenCentral()
maven { url "https://artifact.bytedance.com/repository/pangle" }
maven { url "https://android-sdk.is.com" }
maven { url "https://dl-maven-android.mintegral.com/repository/mbridge_android_sdk_oversea" }
```

Use the code bellow if you need to comply with the Google Family Policy.

```groovy
mavenCentral()
maven { url "https://android-sdk.is.com" }
```

Use the code bellow if you need to use lightweight SDK.

```groovy
mavenCentral()
```

#### 2.1 Add a Gradle dependency

Before

```groovy
implementation 'com.yodo1.mas:full:4.8.0'

implementation 'com.yodo1.mas:google:4.8.0'

implementation 'com.yodo1.mas:lite:4.8.0'
```

After

```groovy
implementation 'com.yodo1.mas:full:4.8.1'

implementation 'com.yodo1.mas:google:4.8.1'

implementation 'com.yodo1.mas:lite:4.8.1'
```

#### For Java
```java
// If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
// Turn on delay if autoDelayIfLoadFail = true
Yodo1MasInterstitialAd.getInstance().autoDelayIfLoadFail = true;
Yodo1MasRewardAd.getInstance().autoDelayIfLoadFail = true;
Yodo1MasAppOpenAd.getInstance().autoDelayIfLoadFail = true;
Yodo1MasRewardedInterstitialAd.getInstance().autoDelayIfLoadFail = true;
```

#### For Kotlin
```java
// If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
// Turn on delay if autoDelayIfLoadFail = true
Yodo1MasInterstitialAd.getInstance().autoDelayIfLoadFail = true;
Yodo1MasRewardAd.getInstance().autoDelayIfLoadFail = true;
Yodo1MasAppOpenAd.getInstance().autoDelayIfLoadFail = true;
Yodo1MasRewardedInterstitialAd.getInstance().autoDelayIfLoadFail = true;
```

## iOS

Before
```
pod 'Yodo1MasFull', '4.8.0'

pod 'Yodo1MasLite', '4.8.0'
```

After
```
pod 'Yodo1MasFull', '4.8.1'

pod 'Yodo1MasLite', '4.8.1'
```

#### For Objective-C
```objc
// If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
// Turn on delay if autoDelayIfLoadFail = YES
[Yodo1MasInterstitialAd sharedInstance].autoDelayIfLoadFail = YES;
[Yodo1MasRewardAd sharedInstance].autoDelayIfLoadFail = YES;
[Yodo1MasAppOpenAd sharedInstance].autoDelayIfLoadFail = YES;
[Yodo1MasRewardedInterstitialAd sharedInstance].autoDelayIfLoadFail = YES;
```

#### For Swift
```objc
// If LoadAd method is called in AdLoadFailed callback, there are chances of this function getting called continuously which might lead to ANRs or other errors. So we recommend that you retry with exponentially higher delays, up to a maximum delay. You can use the below boolean variable to turn on ad load retrying exponentially with higher delays from 2 seconds to 32 seconds. By default, this variable will be false. If this variable is enabled, then the AdFailedToLoad callback will be triggered with the above mentioned delays. 
// Turn on delay if autoDelayIfLoadFail = true
Yodo1MasInterstitialAd.sharedInstance().autoDelayIfLoadFail = true;
Yodo1MasRewardAd.sharedInstance().autoDelayIfLoadFail = true;
Yodo1MasAppOpenAd.sharedInstance().autoDelayIfLoadFail = true;
Yodo1MasRewardedInterstitialAd.sharedInstance().autoDelayIfLoadFail = true;
```

### Update SKAdNetworkIDs
```xml
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>275upjj5gd.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>294l99pt4k.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>2fnua5tdw4.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>2u9pt9hc89.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>3rd42ekr43.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>4468km3ulz.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>44jx6755aq.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>44n7hlldy6.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>4fzdc2evr5.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>4pfyvq9l8r.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>523jb4fst2.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>578prtvx9j.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>5l3tpt7t6e.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>5lm9lj6jb7.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>6964rsfnh4.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>6g9af3uyq4.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>74b6s63p6l.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>7rz58n8ntl.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>7ug5zh24hu.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>84993kbrcf.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>8s468mfl3y.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>9nlqeag3gk.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>9rd848q2bz.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>9t245vhmpl.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>a7xqa6mtl2.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>c3frkrj4fj.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>c6k4g5qg8m.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>cg4yq2srnc.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>cj5566h2ga.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>e5fvkxwrpn.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>ejvt5qm6ak.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>g28c52eehv.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>g2y4y55b64.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>gta9lk7p23.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>hs6bdukanm.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>kbd757ywx3.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>kbmxgpxpgc.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>klf5c3l5u5.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>m8dbw4sv7c.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>mlmmfzh3r3.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>mtkv5xtk9e.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>n6fk4nfna4.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>n9x2a789qt.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>ppxm28t8ap.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>prcb7njmu6.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>pwa73g5rt2.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>pwdxu55a5a.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>qqp299437r.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>r45fhb6rf7.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>rx5hdcabgc.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>t38b2kh725.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>tl55sbb4fm.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>u679fj5vs4.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>uw77j35x4d.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>v72qych5uu.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>wg4vff78zm.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>wzmmz9fp6w.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>yclnxrl5pm.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>ydx93a7ass.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>22mmun2rn5.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>3qcr597p9d.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>3qy4746246.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>3sh42y64q3.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>424m5254lk.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>47vhws6wlr.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>4dzt52r2t5.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>5a6flpkh64.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>8c4e2ghe7u.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>a2p9lx4jpn.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>av6w8kgt66.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>cp8zw746q7.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>cstr6suwn9.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>ecpz2srf59.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>f38h382jlk.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>ludvb6z3bs.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>n38lu8286q.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>p78axxw29g.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>s39g8k73mm.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>v4nxqhlyqp.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>v9wttpbfk9.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>y5ghdn5j9k.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>zq492l623r.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>24t9a8vw3c.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>32z4fx6l9h.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>3l6bd9hu43.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>52fl2v3hgk.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>54nzkqm89y.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>5tjdwbrq8w.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>6xzpu9s2p8.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>79pbpufp6p.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>9b89h5y424.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>9yg77x724h.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>a8cz6cu7e5.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>dkc879ngq3.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>feyaarzu9v.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>ggvn48r87g.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>glqzh8vgby.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>k674qkevps.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>m5mvw97r93.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>n66cz3y3bx.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>nzq8sh4pbs.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>rvh3l7un93.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>vcra2ehyfk.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>x44k69ngh6.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>x5l83yy675.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>x8jxxk4ff5.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>x8uqf25wch.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>xy9t38ct57.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>zmvfpc5aq8.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>252b5q8x7y.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>9g2aggbj52.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>dzg6xy7pwj.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>f73kdq92p3.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>hdw39hrw9y.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>krvm3zuq6h.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>y45688jllp.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>97r2b46745.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>b9bk5wbcq9.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>mls7yz5dvl.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>w9q455wk68.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>su67r6k2v3.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>737z793b9f.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>238da6jt44.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>488r3q3dtq.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>gvmwg8q7h5.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>lr83yxwka7.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>pu4na253f3.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>v79kvwwj4g.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>yrqqpx2mcb.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>z4gj7hsk7h.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>x2jnk7ly8j.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>4w7y6s5ca2.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>f7s53z58qe.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>mp6xlyr22a.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>7953jerfzd.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>7fmhfwg9en.skadnetwork</string>
</dict>
<dict>
    <key>SKAdNetworkIdentifier</key>
    <string>qu637u8glc.skadnetwork</string>
</dict>
```