### PR TITLE
4.8.7

### DIFF
--- a/markdowns/integration-android.md
+++ b/markdowns/integration-android.md
@@ -43,19 +43,19 @@ mavenCentral()
 #### 2.1 Add a Gradle dependency
 
 ```groovy
-implementation 'com.yodo1.mas:full:4.8.6'
+implementation 'com.yodo1.mas:full:4.8.7'
 ```
 
 If you need to comply with Google Family Policy:
 
 ```groovy
-implementation 'com.yodo1.mas:google:4.8.6'
+implementation 'com.yodo1.mas:google:4.8.7'
 ```
 
 If you need to use lightweight SDK:
 
 ```groovy
-implementation 'com.yodo1.mas:lite:4.8.6'
+implementation 'com.yodo1.mas:lite:4.8.7'
 ```
 
 #### 2.2 Add the `compileOptions` property to the `Android` section
@@ -1739,10 +1739,8 @@ class MainActivity : AppCompatActivity() {
 
 ### 4. Cold Starts and Loading Screens
 #### Listen for App Foregrounding Events
-To be notified of app foregrounding events, you need to register a LifecycleObserver. You may need to add a lifecycle library to your application-level build.gradlefile:
-```
-implementation("androidx.lifecycle:lifecycle-process:2.2.0")
-```
+To be notified of app foregrounding events, You can listen for these events through the `Yodo1Mas.AppStatusListener` class.
+
 
 For Java
 
@@ -1753,54 +1751,54 @@ import ...
 import com.yodo1.mas.Yodo1Mas;
 import com.yodo1.mas.appopenad.Yodo1MasAppOpenAd;
 import com.yodo1.mas.appopenad.Yodo1MasAppOpenAdListener;
+import com.yodo1.mas.error.Yodo1MasError;
 
-public class MyApplication extends Application implements LifecycleObserver
-{
-   private Yodo1MasAppOpenAd appOpenAd = Yodo1MasAppOpenAd.getInstance();
+public class AppOpenAdActivity extends AppCompatActivity {
 
-   @Override
-   public void onCreate() {
-       super.onCreate();
-       ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
-       appOpenAd.setAdListener(new Yodo1MasAppOpenAdListener() {
-		    @Override
-		    public void onAppOpenAdLoaded(Yodo1MasAppOpenAd ad) {
-		        
-		    }
-		
-		    @Override
-		    public void onAppOpenAdFailedToLoad(Yodo1MasAppOpenAd ad, @NonNull Yodo1MasError error) {
-		        ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity());
-		    }
-		
-		    @Override
-		    public void onAppOpenAdOpened(Yodo1MasAppOpenAd ad) {
-		        
-		    }
-		
-		    @Override
-		    public void onAppOpenAdFailedToOpen(Yodo1MasAppOpenAd ad, @NonNull Yodo1MasError error) {
-				ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity());
-		    }
-		
-		    @Override
-		    public void onAppOpenAdClosed(Yodo1MasAppOpenAd ad) {
-		        ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity());
-		    }
-		 });
-   }
+    private Yodo1MasAppOpenAd appOpenAd = Yodo1MasAppOpenAd.getInstance();
 
-   /** LifecycleObserver method that shows the app open ad when the app moves to foreground. */
-   @OnLifecycleEvent(Lifecycle.Event.ON_START)
-   public void onMoveToForeground() {
-        Activity activity = Yodo1Mas.getInstance().getCurrentActivity();
-        if (activity == null) return;  
-        if (appOpenAd.isLoaded()) {
-            appOpenAd.showAd(activity, "Your placement id");
-        } else {
-            appOpenAd.loadAd(activity);
-        }
-   }
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        appOpenAd.setAdListener(new Yodo1MasAppOpenAdListener() {
+            @Override
+            public void onAppOpenAdLoaded(Yodo1MasAppOpenAd ad) {
+
+            }
+
+            @Override
+            public void onAppOpenAdFailedToLoad(Yodo1MasAppOpenAd ad, @NonNull Yodo1MasError error) {
+                ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity());
+            }
+
+            @Override
+            public void onAppOpenAdOpened(Yodo1MasAppOpenAd ad) {
+
+            }
+
+            @Override
+            public void onAppOpenAdFailedToOpen(Yodo1MasAppOpenAd ad, @NonNull Yodo1MasError error) {
+                ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity());
+            }
+
+            @Override
+            public void onAppOpenAdClosed(Yodo1MasAppOpenAd ad) {
+                ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity());
+            }
+        });
+
+        Yodo1Mas.getInstance().setAppStatusListener(new Yodo1Mas.AppStatusListener() {
+            @Override
+            public void onApplicationEnterForeground() {
+                if (appOpenAd.isLoaded()) {
+                    appOpenAd.showAd(AppOpenAdActivity.this, "Your placement id");
+                } else {
+                    appOpenAd.loadAd(AppOpenAdActivity.this);
+                }
+            }
+        });
+    }
 }
 ```
 
@@ -1810,62 +1808,36 @@ For Kotlin
 package ...
 
 import ...
-import com.yodo1.mas.Yodo1Mas;
-import com.yodo1.mas.appopenad.Yodo1MasAppOpenAd;
-import com.yodo1.mas.appopenad.Yodo1MasAppOpenAdListener;
+import com.yodo1.mas.appopenad.Yodo1MasAppOpenAdListener
+import com.yodo1.mas.error.Yodo1MasError
+import com.yodo1.mas.Yodo1Mas
+import com.yodo1.mas.Yodo1Mas.AppStatusListener
 
-class MyApplication : Application(), LifecycleObserver {
-
-    val appOpenAd = Yodo1MasAppOpenAd.getInstance()
-
-    override fun onCreate() {
-        super.onCreate()
-        ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
+class AppOpenAdActivity : AppCompatActivity() {
+    private val appOpenAd = Yodo1MasAppOpenAd.getInstance()
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
         appOpenAd.setAdListener(object : Yodo1MasAppOpenAdListener {
-            override fun onAppOpenAdLoaded(ad: Yodo1MasAppOpenAd?) {
-                // Code to be executed when an ad finishes loading.
-                
+            override fun onAppOpenAdLoaded(ad: Yodo1MasAppOpenAd) {}
+            override fun onAppOpenAdFailedToLoad(ad: Yodo1MasAppOpenAd, error: Yodo1MasError) {
+                ad.loadAd(Yodo1Mas.getInstance().currentActivity)
             }
 
-            override fun onAppOpenAdFailedToLoad(
-                ad: Yodo1appOpenAd?,
-                error: Yodo1MasError
-            ) {
-                // Code to be executed when an ad request fails.
-                ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity())
+            override fun onAppOpenAdOpened(ad: Yodo1MasAppOpenAd) {}
+            override fun onAppOpenAdFailedToOpen(ad: Yodo1MasAppOpenAd, error: Yodo1MasError) {
+                ad.loadAd(Yodo1Mas.getInstance().currentActivity)
             }
 
-            override fun onAppOpenAdOpened(ad: Yodo1MasAppOpenAd?) {
-                // Code to be executed when an ad opens an overlay that
-		         // covers the screen.
-            }
-
-            override fun onAppOpenAdFailedToOpen(
-                ad: Yodo1MasAppOpenAd?,
-                error: Yodo1MasError
-            ) {
-                // Code to be executed when an ad open fails.
-                ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity())
-            }
-
-            override fun onAppOpenAdClosed(ad: Yodo1MasAppOpenAd?) {
-                // Code to be executed when the user is about to return
-		         // to the app after tapping on an ad.
-                 ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity())
+            override fun onAppOpenAdClosed(ad: Yodo1MasAppOpenAd) {
+                ad.loadAd(Yodo1Mas.getInstance().currentActivity)
             }
         })
-        
-    }
-
-    /** LifecycleObserver method that shows the app open ad when the app moves to foreground. */
-    @OnLifecycleEvent(Lifecycle.Event.ON_START)
-    fun onMoveToForeground() {
-        var activity = Yodo1Mas.getInstance().getCurrentActivity()
-        if (activity == null) return 
-        if (appOpenAd.isLoaded()) {
-            appOpenAd.showAd(activity, "Your placement id")
-        } else {
-            appOpenAd.loadAd(activity)
+        Yodo1Mas.getInstance().setAppStatusListener {
+            if (appOpenAd.isLoaded) {
+                appOpenAd.showAd(this@AppOpenAdActivity, "Your placement id")
+            } else {
+                appOpenAd.loadAd(this@AppOpenAdActivity)
+            }
         }
     }
 }

--- a/markdowns/integration-ios.md
+++ b/markdowns/integration-ios.md
@@ -1971,7 +1971,7 @@ For Objective-C
 #import "AppDelegate.h"
 #import <Yodo1MasCore/Yodo1Mas.h>
 
-@interface AppDelegate ()<Yodo1MasAppOpenAdDelegate>
+@interface AppDelegate ()<Yodo1MasAppStatusDelegate, Yodo1MasAppOpenAdDelegate>
 
 @property (nonatomic, strong) Yodo1MasAppOpenAd *appOpenAd;
 
@@ -1980,14 +1980,18 @@ For Objective-C
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+
+    [Yodo1Mas sharedInstance].appStatusDelegate = self;
+
     _appOpenAd = [Yodo1MasAppOpenAd sharedInstance];
     _appOpenAd.adDelegate = self;
     [_appOpenAd loadAd];
     return YES;
 }
 
-- (void)applicationDidBecomeActive:(UIApplication *)application {
-    if (_appOpenAd && _appOpenAd.isLoaded) {
+#pragma mark - Yodo1MasAppStatusDelegate
+- (void)onApplicationEnterForeground {
+     if (_appOpenAd && _appOpenAd.isLoaded) {
         [_appOpenAd showAd];
     }
 }
@@ -2025,6 +2029,9 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var appOpenAd: Yodo1MasAppOpenAd!
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+        Yodo1Mas.sharedInstance().appStatusDelegate = self;
+
         appOpenAd = Yodo1MasAppOpenAd.sharedInstance()
         appOpenAd.setAdPlacement("Your Placement Id")
         appOpenAd.adDelegate = self
@@ -2032,14 +2039,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    func applicationDidBecomeActive(_ application: UIApplication) {
+    
+}
+
+extension AppDelegate: Yodo1MasAppStatusDelegate, Yodo1MasAppOpenAdDelegate {
+
+    // MARK: Yodo1MasAppStatusDelegate
+    func onApplicationEnterForeground {
         if (appOpenAd.isLoaded) {
             appOpenAd.show();
         }
     }
-}
 
-extension AppDelegate: Yodo1MasAppOpenAdDelegate {
     // MARK: Yodo1MasAppOpenAdDelegate
     func onAppOpenAdLoaded(_ ad: Yodo1MasAppOpenAd) {
         

--- a/markdowns/integration-ios.md
+++ b/markdowns/integration-ios.md
@@ -31,7 +31,7 @@
 	source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
 	source 'https://github.com/Yodo1Games/MAS-Spec.git'
 	
-	pod 'Yodo1MasFull', '4.8.6'
+	pod 'Yodo1MasFull', '4.8.7'
 	```
 
   If you need to use lightweight SDK:
@@ -41,7 +41,7 @@
   source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
   source 'https://github.com/Yodo1Games/MAS-Spec.git'
   
-  pod 'Yodo1MasLite', '4.8.6'
+  pod 'Yodo1MasLite', '4.8.7'
   ```
 	
 	Execute the following command in `Terminal` :

--- a/markdowns/integration-unity.md
+++ b/markdowns/integration-unity.md
@@ -17,11 +17,11 @@ MAS provides 3 versions of the Unity plugin, and you need to select one dependin
 * If your game is not part of the “Designed for Families Program”, please use the Standard SDK.
 * If your game prefers to use the 4 top ad networks to keep the SDK lightweight without making significant compromises on Monetization, please use the Lite SDK.
 
-[Designed For Families](https://mas-artifacts.yodo1.com/4.8.6/Unity/Release/Rivendell-4.8.6-Family.unitypackage)
+[Designed For Families](https://mas-artifacts.yodo1.com/4.8.7/Unity/Release/Rivendell-4.8.7-Family.unitypackage)
 
-[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.8.6/Unity/Release/Rivendell-4.8.6-Full.unitypackage)
+[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.8.7/Unity/Release/Rivendell-4.8.7-Full.unitypackage)
 
-[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.8.6/Unity/Release/Rivendell-4.8.6-Lite.unitypackage)
+[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.8.7/Unity/Release/Rivendell-4.8.7-Lite.unitypackage)
 
 ### Note:
 If you are use unity **2018**,please check on the Custom Gradle Template through the following steps:

--- a/markdowns/integration-unity.md
+++ b/markdowns/integration-unity.md
@@ -679,6 +679,7 @@ private void InitializeInterstitialAds()
 	// Add Events
     Yodo1U3dMasCallback.Interstitial.OnAdLoadedEvent += OnInterstitialAdLoadedEvent;
     Yodo1U3dMasCallback.Interstitial.OnAdLoadFailedEvent += OnInterstitialAdLoadFailedEvent;
+    Yodo1U3dInterstitialAd.GetInstance().OnAdOpeningEvent += OnInterstitialAdOpeningEvent;
     Yodo1U3dMasCallback.Interstitial.OnAdOpenedEvent += OnInterstitialAdOpenedEvent;
     Yodo1U3dMasCallback.Interstitial.OnAdOpenFailedEvent += OnInterstitialAdOpenFailedEvent;
     Yodo1U3dMasCallback.Interstitial.OnAdClosedEvent += OnInterstitialAdClosedEvent;
@@ -692,6 +693,11 @@ private void OnInterstitialAdLoadedEvent()
 private void OnInterstitialAdLoadFailedEvent(Yodo1U3dAdError adError) 
 {
     Debug.Log("[Yodo1 Mas] Interstitial ad load error - " + adError.ToString());
+}
+
+private void OnInterstitialAdOpeningEvent(Yodo1U3dInterstitialAd ad)
+{
+    Debug.Log(Yodo1U3dMas.TAG + "OnInterstitialAdOpeningEvent event received");
 }
 
 private void OnInterstitialAdOpenedEvent()
@@ -1317,6 +1323,13 @@ public class AppOpenSampleV2 : MonoBehaviour
     ...
     public void Start()
     {
+        Yodo1U3dMasCallback.OnAppEnterForegroundEvent += ()=>
+        {
+            if (focus)
+            {
+                appOpenAd.ShowAd();
+            }
+        };
         // Initialize the MAS SDK.
         Yodo1U3dMasCallback.OnSdkInitializedEvent += (success, error) =>{ };
         Yodo1U3dMas.InitializeMasSdk();
@@ -1336,14 +1349,6 @@ public class AppOpenSampleV2 : MonoBehaviour
         appOpenAd.OnAdClosedEvent += OnAppOpenAdClosedEvent;
         appOpenAd.OnAdEarnedEvent += OnAppOpenAdEarnedEvent;
         appOpenAd.LoadAd();
-    }
-
-    private void OnApplicationFocus(bool focus)
-    {
-        if (focus)
-        {
-            appOpenAd.ShowAd();
-        }
     }
 
     private void OnAppOpenAdLoadedEvent(Yodo1U3dAppOpenAd ad)

--- a/markdowns/questions-android.md
+++ b/markdowns/questions-android.md
@@ -34,6 +34,14 @@ Copy
 
 This issue is caused by an incorrect package name. MAS includes many networks and most of them have a bundle-id verification mechanism. You have to use the real package name from your app to get live ads.
 
+## How to view the debuglog?
+From version 4.8.7 the debug log will be hidden by default. If you want to veiw the debug log, please add the following elements under the application node of the AndroidManifest.xml file
 
+```java
+<meta-data
+    android:name="com.yodo1.mas.EnableDebugLogging"
+    android:value="true" />
+
+```
 
 

--- a/markdowns/questions-ios.md
+++ b/markdowns/questions-ios.md
@@ -13,3 +13,13 @@ This pop-up window is from applovin, which will stop appearing by deleting `NSAl
 ## Will integrate with MAS be rejected by Apple because of UIWebView?
 
 No, the MAS SDK does not use UIWebView. To see where UIWebView is used, click [here](https://levelup.gitconnected.com/how-to-find-and-remove-uiwebview-uses-in-your-ios-app-d9395f7baacc).
+
+## How to view the debuglog?
+From version 4.8.7 the debug log will be hidden by default. If you want to view the debug log, please add the following elements to the info.plist file
+
+```
+<dict>
+    <key>EnableDebugLogging</key>
+    <true/>
+</dict>
+```


### PR DESCRIPTION
## Unity
### Update version
Before
[Designed For Families](https://mas-artifacts.yodo1.com/4.8.6/Unity/Release/Rivendell-4.8.6-Family.unitypackage)

[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.8.6/Unity/Release/Rivendell-4.8.6-Full.unitypackage)

[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.8.6/Unity/Release/Rivendell-4.8.6-Lite.unitypackage)

After
[Designed For Families](https://mas-artifacts.yodo1.com/4.8.7/Unity/Release/Rivendell-4.8.7-Family.unitypackage)

[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.8.7/Unity/Release/Rivendell-4.8.7-Full.unitypackage)

[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.8.7/Unity/Release/Rivendell-4.8.7-Lite.unitypackage)

Before
```
public void Start()
{
    // Initialize the MAS SDK.
    Yodo1U3dMasCallback.OnSdkInitializedEvent += (success, error) =>{ };
    Yodo1U3dMas.InitializeMasSdk();

    this.RequestAppOpen();
}

private void InitializeInterstitialAds()
{
	// Add Events
    Yodo1U3dMasCallback.Interstitial.OnAdLoadedEvent += OnInterstitialAdLoadedEvent;
    Yodo1U3dMasCallback.Interstitial.OnAdLoadFailedEvent += OnInterstitialAdLoadFailedEvent;
    Yodo1U3dMasCallback.Interstitial.OnAdOpenedEvent += OnInterstitialAdOpenedEvent;
    Yodo1U3dMasCallback.Interstitial.OnAdOpenFailedEvent += OnInterstitialAdOpenFailedEvent;
    Yodo1U3dMasCallback.Interstitial.OnAdClosedEvent += OnInterstitialAdClosedEvent;
}

private void OnApplicationFocus(bool focus)
{
    if (focus)
    {
        appOpenAd.ShowAd();
    }
}
```

After
```
public void Start()
{
    Yodo1U3dMasCallback.OnAppEnterForegroundEvent += ()=>
    {
        if (focus)
        {
            appOpenAd.ShowAd();
        }
    };
    // Initialize the MAS SDK.
    Yodo1U3dMasCallback.OnSdkInitializedEvent += (success, error) =>{ };
    Yodo1U3dMas.InitializeMasSdk();

    this.RequestAppOpen();
}

private void InitializeInterstitialAds()
{
	// Add Events
    Yodo1U3dMasCallback.Interstitial.OnAdLoadedEvent += OnInterstitialAdLoadedEvent;
    Yodo1U3dMasCallback.Interstitial.OnAdLoadFailedEvent += OnInterstitialAdLoadFailedEvent;
    Yodo1U3dInterstitialAd.GetInstance().OnAdOpeningEvent += OnInterstitialAdOpeningEvent;
    Yodo1U3dMasCallback.Interstitial.OnAdOpenedEvent += OnInterstitialAdOpenedEvent;
    Yodo1U3dMasCallback.Interstitial.OnAdOpenFailedEvent += OnInterstitialAdOpenFailedEvent;
    Yodo1U3dMasCallback.Interstitial.OnAdClosedEvent += OnInterstitialAdClosedEvent;
}

private void OnInterstitialAdOpeningEvent(Yodo1U3dInterstitialAd ad)
{
    Debug.Log(Yodo1U3dMas.TAG + "OnInterstitialAdOpeningEvent event received");
}
```

## iOS
### Update version
Before
```ruby
use_frameworks!
source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
source 'https://github.com/Yodo1Games/MAS-Spec.git'

pod 'Yodo1MasFull', '4.8.6'
```

```ruby
use_frameworks!
source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
source 'https://github.com/Yodo1Games/MAS-Spec.git'

pod 'Yodo1MasLite', '4.8.6'
```

After
```ruby
use_frameworks!
source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
source 'https://github.com/Yodo1Games/MAS-Spec.git'

pod 'Yodo1MasFull', '4.8.7'
```

```ruby
use_frameworks!
source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
source 'https://github.com/Yodo1Games/MAS-Spec.git'

pod 'Yodo1MasLite', '4.8.7'
```

Before
### 4. Cold Starts and Loading Screens
For Objective-C
```obj-c
#import "AppDelegate.h"
#import <Yodo1MasCore/Yodo1Mas.h>

@interface AppDelegate ()<Yodo1MasAppOpenAdDelegate>

@property (nonatomic, strong) Yodo1MasAppOpenAd *appOpenAd;

@end

@implementation AppDelegate

- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
    _appOpenAd = [Yodo1MasAppOpenAd sharedInstance];
    _appOpenAd.adDelegate = self;
    [_appOpenAd loadAd];
    return YES;
}

- (void)applicationDidBecomeActive:(UIApplication *)application {
    if (_appOpenAd && _appOpenAd.isLoaded) {
        [_appOpenAd showAd];
    }
}

#pragma mark - Yodo1MasAppOpenAdDelegate
- (void)onAppOpenAdLoaded:(Yodo1MasAppOpenAd *)ad {
    
}

- (void)onAppOpenAdFailedToLoad:(Yodo1MasAppOpenAd *)ad withError:(Yodo1MasError *)error {
    [ad loadAd];
}

- (void)onAppOpenAdOpened:(Yodo1MasAppOpenAd *)ad {
    
}

- (void)onAppOpenAdFailedToOpen:(Yodo1MasAppOpenAd *)ad withError:(Yodo1MasError *)error {
    [ad loadAd];
}

- (void)onAppOpenAdClosed:(Yodo1MasAppOpenAd *)ad {
    [ad loadAd];
}

@end

```

For Swift
```swift
import UIKit

@main
class AppDelegate: UIResponder, UIApplicationDelegate {
    var appOpenAd: Yodo1MasAppOpenAd!
    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
        appOpenAd = Yodo1MasAppOpenAd.sharedInstance()
        appOpenAd.setAdPlacement("Your Placement Id")
        appOpenAd.adDelegate = self
        appOpenAd.load()
        return true
    }

    func applicationDidBecomeActive(_ application: UIApplication) {
        if (appOpenAd.isLoaded) {
            appOpenAd.show();
        }
    }
}

extension AppDelegate: Yodo1MasAppOpenAdDelegate {
    // MARK: Yodo1MasAppOpenAdDelegate
    func onAppOpenAdLoaded(_ ad: Yodo1MasAppOpenAd) {
        
    }
    
    func onAppOpenAdFailed(toLoad ad: Yodo1MasAppOpenAd, withError error: Yodo1MasError) {
        ad.load()
    }
    
    func onAppOpenAdOpened(_ ad: Yodo1MasAppOpenAd) {
        
    }
    
    func onAppOpenAdFailed(toOpen ad: Yodo1MasAppOpenAd, withError error: Yodo1MasError) {
        ad.load()
    }
    
    func onAppOpenAdClosed(_ ad: Yodo1MasAppOpenAd) {
        ad.load()
    }
}
```

After
### 4. Cold Starts and Loading Screens
For Objective-C
```obj-c
#import "AppDelegate.h"
#import <Yodo1MasCore/Yodo1Mas.h>

@interface AppDelegate ()<Yodo1MasAppStatusDelegate, Yodo1MasAppOpenAdDelegate>

@property (nonatomic, strong) Yodo1MasAppOpenAd *appOpenAd;

@end

@implementation AppDelegate

- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {

    [Yodo1Mas sharedInstance].appStatusDelegate = self;

    _appOpenAd = [Yodo1MasAppOpenAd sharedInstance];
    _appOpenAd.adDelegate = self;
    [_appOpenAd loadAd];
    return YES;
}

#pragma mark - Yodo1MasAppStatusDelegate
- (void)onApplicationEnterForeground {
     if (_appOpenAd && _appOpenAd.isLoaded) {
        [_appOpenAd showAd];
    }
}

#pragma mark - Yodo1MasAppOpenAdDelegate
- (void)onAppOpenAdLoaded:(Yodo1MasAppOpenAd *)ad {
    
}

- (void)onAppOpenAdFailedToLoad:(Yodo1MasAppOpenAd *)ad withError:(Yodo1MasError *)error {
    [ad loadAd];
}

- (void)onAppOpenAdOpened:(Yodo1MasAppOpenAd *)ad {
    
}

- (void)onAppOpenAdFailedToOpen:(Yodo1MasAppOpenAd *)ad withError:(Yodo1MasError *)error {
    [ad loadAd];
}

- (void)onAppOpenAdClosed:(Yodo1MasAppOpenAd *)ad {
    [ad loadAd];
}

@end

```

For Swift
```swift
import UIKit

@main
class AppDelegate: UIResponder, UIApplicationDelegate {
    var appOpenAd: Yodo1MasAppOpenAd!
    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {

        Yodo1Mas.sharedInstance().appStatusDelegate = self;

        appOpenAd = Yodo1MasAppOpenAd.sharedInstance()
        appOpenAd.setAdPlacement("Your Placement Id")
        appOpenAd.adDelegate = self
        appOpenAd.load()
        return true
    }

    
}

extension AppDelegate: Yodo1MasAppStatusDelegate, Yodo1MasAppOpenAdDelegate {

    // MARK: Yodo1MasAppStatusDelegate
    func onApplicationEnterForeground {
        if (appOpenAd.isLoaded) {
            appOpenAd.show();
        }
    }

    // MARK: Yodo1MasAppOpenAdDelegate
    func onAppOpenAdLoaded(_ ad: Yodo1MasAppOpenAd) {
        
    }
    
    func onAppOpenAdFailed(toLoad ad: Yodo1MasAppOpenAd, withError error: Yodo1MasError) {
        ad.load()
    }
    
    func onAppOpenAdOpened(_ ad: Yodo1MasAppOpenAd) {
        
    }
    
    func onAppOpenAdFailed(toOpen ad: Yodo1MasAppOpenAd, withError error: Yodo1MasError) {
        ad.load()
    }
    
    func onAppOpenAdClosed(_ ad: Yodo1MasAppOpenAd) {
        ad.load()
    }
}
```

## How to view the debuglog?
From version 4.8.7 the debug log will be hidden by default. If you want to view the debug log, please add the following elements to the info.plist file

```
<dict>
    <key>EnableDebugLogging</key>
    <true/>
</dict>
```

## Android
### Update version
Before
```groovy
implementation 'com.yodo1.mas:full:4.8.6'
```

```groovy
implementation 'com.yodo1.mas:google:4.8.6'
```

```groovy
implementation 'com.yodo1.mas:lite:4.8.6'
```

After
```groovy
implementation 'com.yodo1.mas:full:4.8.7'
```

```groovy
implementation 'com.yodo1.mas:google:4.8.7'
```

```groovy
implementation 'com.yodo1.mas:lite:4.8.7'
```

Before
### 4. Cold Starts and Loading Screens
#### Listen for App Foregrounding Events
To be notified of app foregrounding events, you need to register a LifecycleObserver. You may need to add a lifecycle library to your application-level build.gradlefile:
```
implementation("androidx.lifecycle:lifecycle-process:2.2.0")
```

For Java

```java
package ...

import ...
import com.yodo1.mas.Yodo1Mas;
import com.yodo1.mas.appopenad.Yodo1MasAppOpenAd;
import com.yodo1.mas.appopenad.Yodo1MasAppOpenAdListener;

public class MyApplication extends Application implements LifecycleObserver
{
   private Yodo1MasAppOpenAd appOpenAd = Yodo1MasAppOpenAd.getInstance();

   @Override
   public void onCreate() {
       super.onCreate();
       ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
       appOpenAd.setAdListener(new Yodo1MasAppOpenAdListener() {
		    @Override
		    public void onAppOpenAdLoaded(Yodo1MasAppOpenAd ad) {
		        
		    }
		
		    @Override
		    public void onAppOpenAdFailedToLoad(Yodo1MasAppOpenAd ad, @NonNull Yodo1MasError error) {
		        ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity());
		    }
		
		    @Override
		    public void onAppOpenAdOpened(Yodo1MasAppOpenAd ad) {
		        
		    }
		
		    @Override
		    public void onAppOpenAdFailedToOpen(Yodo1MasAppOpenAd ad, @NonNull Yodo1MasError error) {
				ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity());
		    }
		
		    @Override
		    public void onAppOpenAdClosed(Yodo1MasAppOpenAd ad) {
		        ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity());
		    }
		 });
   }

   /** LifecycleObserver method that shows the app open ad when the app moves to foreground. */
   @OnLifecycleEvent(Lifecycle.Event.ON_START)
   public void onMoveToForeground() {
        Activity activity = Yodo1Mas.getInstance().getCurrentActivity();
        if (activity == null) return;  
        if (appOpenAd.isLoaded()) {
            appOpenAd.showAd(activity, "Your placement id");
        } else {
            appOpenAd.loadAd(activity);
        }
   }
}
```

For Kotlin

```kotlin
package ...

import ...
import com.yodo1.mas.Yodo1Mas;
import com.yodo1.mas.appopenad.Yodo1MasAppOpenAd;
import com.yodo1.mas.appopenad.Yodo1MasAppOpenAdListener;

class MyApplication : Application(), LifecycleObserver {

    val appOpenAd = Yodo1MasAppOpenAd.getInstance()

    override fun onCreate() {
        super.onCreate()
        ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
        appOpenAd.setAdListener(object : Yodo1MasAppOpenAdListener {
            override fun onAppOpenAdLoaded(ad: Yodo1MasAppOpenAd?) {
                // Code to be executed when an ad finishes loading.
                
            }

            override fun onAppOpenAdFailedToLoad(
                ad: Yodo1appOpenAd?,
                error: Yodo1MasError
            ) {
                // Code to be executed when an ad request fails.
                ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity())
            }

            override fun onAppOpenAdOpened(ad: Yodo1MasAppOpenAd?) {
                // Code to be executed when an ad opens an overlay that
		         // covers the screen.
            }

            override fun onAppOpenAdFailedToOpen(
                ad: Yodo1MasAppOpenAd?,
                error: Yodo1MasError
            ) {
                // Code to be executed when an ad open fails.
                ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity())
            }

            override fun onAppOpenAdClosed(ad: Yodo1MasAppOpenAd?) {
                // Code to be executed when the user is about to return
		         // to the app after tapping on an ad.
                 ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity())
            }
        })
        
    }

    /** LifecycleObserver method that shows the app open ad when the app moves to foreground. */
    @OnLifecycleEvent(Lifecycle.Event.ON_START)
    fun onMoveToForeground() {
        var activity = Yodo1Mas.getInstance().getCurrentActivity()
        if (activity == null) return 
        if (appOpenAd.isLoaded()) {
            appOpenAd.showAd(activity, "Your placement id")
        } else {
            appOpenAd.loadAd(activity)
        }
    }
}
```
After
### 4. Cold Starts and Loading Screens
#### Listen for App Foregrounding Events
To be notified of app foregrounding events, You can listen for these events through the `Yodo1Mas.AppStatusListener` class.


For Java

```java
package ...

import ...
import com.yodo1.mas.Yodo1Mas;
import com.yodo1.mas.appopenad.Yodo1MasAppOpenAd;
import com.yodo1.mas.appopenad.Yodo1MasAppOpenAdListener;
import com.yodo1.mas.error.Yodo1MasError;

public class AppOpenAdActivity extends AppCompatActivity {

    private Yodo1MasAppOpenAd appOpenAd = Yodo1MasAppOpenAd.getInstance();

    @Override
    protected void onCreate(@Nullable Bundle savedInstanceState) {
        super.onCreate(savedInstanceState);

        appOpenAd.setAdListener(new Yodo1MasAppOpenAdListener() {
            @Override
            public void onAppOpenAdLoaded(Yodo1MasAppOpenAd ad) {

            }

            @Override
            public void onAppOpenAdFailedToLoad(Yodo1MasAppOpenAd ad, @NonNull Yodo1MasError error) {
                ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity());
            }

            @Override
            public void onAppOpenAdOpened(Yodo1MasAppOpenAd ad) {

            }

            @Override
            public void onAppOpenAdFailedToOpen(Yodo1MasAppOpenAd ad, @NonNull Yodo1MasError error) {
                ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity());
            }

            @Override
            public void onAppOpenAdClosed(Yodo1MasAppOpenAd ad) {
                ad.loadAd(Yodo1Mas.getInstance().getCurrentActivity());
            }
        });

        Yodo1Mas.getInstance().setAppStatusListener(new Yodo1Mas.AppStatusListener() {
            @Override
            public void onApplicationEnterForeground() {
                if (appOpenAd.isLoaded()) {
                    appOpenAd.showAd(AppOpenAdActivity.this, "Your placement id");
                } else {
                    appOpenAd.loadAd(AppOpenAdActivity.this);
                }
            }
        });
    }
}
```

For Kotlin

```kotlin
package ...

import ...
import com.yodo1.mas.appopenad.Yodo1MasAppOpenAdListener
import com.yodo1.mas.error.Yodo1MasError
import com.yodo1.mas.Yodo1Mas
import com.yodo1.mas.Yodo1Mas.AppStatusListener

class AppOpenAdActivity : AppCompatActivity() {
    private val appOpenAd = Yodo1MasAppOpenAd.getInstance()
    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        appOpenAd.setAdListener(object : Yodo1MasAppOpenAdListener {
            override fun onAppOpenAdLoaded(ad: Yodo1MasAppOpenAd) {}
            override fun onAppOpenAdFailedToLoad(ad: Yodo1MasAppOpenAd, error: Yodo1MasError) {
                ad.loadAd(Yodo1Mas.getInstance().currentActivity)
            }

            override fun onAppOpenAdOpened(ad: Yodo1MasAppOpenAd) {}
            override fun onAppOpenAdFailedToOpen(ad: Yodo1MasAppOpenAd, error: Yodo1MasError) {
                ad.loadAd(Yodo1Mas.getInstance().currentActivity)
            }

            override fun onAppOpenAdClosed(ad: Yodo1MasAppOpenAd) {
                ad.loadAd(Yodo1Mas.getInstance().currentActivity)
            }
        })
        Yodo1Mas.getInstance().setAppStatusListener {
            if (appOpenAd.isLoaded) {
                appOpenAd.showAd(this@AppOpenAdActivity, "Your placement id")
            } else {
                appOpenAd.loadAd(this@AppOpenAdActivity)
            }
        }
    }
}
```

## How to view the debuglog?
From version 4.8.7 the debug log will be hidden by default. If you want to veiw the debug log, please add the following elements under the application node of the AndroidManifest.xml file

```java
<meta-data
    android:name="com.yodo1.mas.EnableDebugLogging"
    android:value="true" />
```