### PR TITLE
version 4.8.9

### DIFF
--- a/markdowns/integration-android.md
+++ b/markdowns/integration-android.md
@@ -43,19 +43,19 @@ mavenCentral()
 #### 2.1 Add a Gradle dependency
 
 ```groovy
-implementation 'com.yodo1.mas:full:4.8.8'
+implementation 'com.yodo1.mas:full:4.8.9'
 ```
 
 If you need to comply with Google Family Policy:
 
 ```groovy
-implementation 'com.yodo1.mas:google:4.8.8'
+implementation 'com.yodo1.mas:google:4.8.9'
 ```
 
 If you need to use lightweight SDK:
 
 ```groovy
-implementation 'com.yodo1.mas:lite:4.8.8'
+implementation 'com.yodo1.mas:lite:4.8.9'
 ```
 
 #### 2.2 Add the `compileOptions` property to the `Android` section

--- a/markdowns/integration-ios.md
+++ b/markdowns/integration-ios.md
@@ -31,7 +31,7 @@
 	source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
 	source 'https://github.com/Yodo1Games/MAS-Spec.git'
 	
-	pod 'Yodo1MasFull', '4.8.8'
+	pod 'Yodo1MasFull', '4.8.9'
 	```
 
   If you need to use lightweight SDK:
@@ -41,7 +41,7 @@
   source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
   source 'https://github.com/Yodo1Games/MAS-Spec.git'
   
-  pod 'Yodo1MasLite', '4.8.8'
+  pod 'Yodo1MasLite', '4.8.9'
   ```
 	
 	Execute the following command in `Terminal` :

--- a/markdowns/integration-unity.md
+++ b/markdowns/integration-unity.md
@@ -17,11 +17,11 @@ MAS provides 3 versions of the Unity plugin, and you need to select one dependin
 * If your game is not part of the “Designed for Families Program”, please use the Standard SDK.
 * If your game prefers to use the 4 top ad networks to keep the SDK lightweight without making significant compromises on Monetization, please use the Lite SDK.
 
-[Designed For Families](https://mas-artifacts.yodo1.com/4.8.8/Unity/Release/Rivendell-4.8.8-Family.unitypackage)
+[Designed For Families](https://mas-artifacts.yodo1.com/4.8.9/Unity/Release/Rivendell-4.8.9-Family.unitypackage)
 
-[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.8.8/Unity/Release/Rivendell-4.8.8-Full.unitypackage)
+[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.8.9/Unity/Release/Rivendell-4.8.9-Full.unitypackage)
 
-[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.8.8/Unity/Release/Rivendell-4.8.8-Lite.unitypackage)
+[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.8.9/Unity/Release/Rivendell-4.8.9-Lite.unitypackage)
 
 ### Note:
 If you are use unity **2018**,please check on the Custom Gradle Template through the following steps:


### PR DESCRIPTION
## Unity
### Update version
Before
[Designed For Families](https://mas-artifacts.yodo1.com/4.8.8/Unity/Release/Rivendell-4.8.8-Family.unitypackage)

[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.8.8/Unity/Release/Rivendell-4.8.8-Full.unitypackage)

[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.8.8/Unity/Release/Rivendell-4.8.8-Lite.unitypackage)

After
[Designed For Families](https://mas-artifacts.yodo1.com/4.8.9/Unity/Release/Rivendell-4.8.9-Family.unitypackage)

[Standard MAS Plugin](https://mas-artifacts.yodo1.com/4.8.9/Unity/Release/Rivendell-4.8.9-Full.unitypackage)

[Lightweight MAS Plugin](https://mas-artifacts.yodo1.com/4.8.9/Unity/Release/Rivendell-4.8.9-Lite.unitypackage)

## iOS
### Update version
Before
```ruby
use_frameworks!
source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
source 'https://github.com/Yodo1Games/MAS-Spec.git'

pod 'Yodo1MasFull', '4.8.8'
```

```ruby
use_frameworks!
source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
source 'https://github.com/Yodo1Games/MAS-Spec.git'

pod 'Yodo1MasLite', '4.8.8'
```

After
```ruby
use_frameworks!
source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
source 'https://github.com/Yodo1Games/MAS-Spec.git'

pod 'Yodo1MasFull', '4.8.9'
```

```ruby
use_frameworks!
source 'https://github.com/CocoaPods/Specs.git'  # recommend: source 'https://cdn.cocoapods.org/'
source 'https://github.com/Yodo1Games/MAS-Spec.git'

pod 'Yodo1MasLite', '4.8.9'
```

## Android
### Update version
Before
```groovy
implementation 'com.yodo1.mas:full:4.8.8'
```

```groovy
implementation 'com.yodo1.mas:google:4.8.8'
```

```groovy
implementation 'com.yodo1.mas:lite:4.8.8'
```

After
```groovy
implementation 'com.yodo1.mas:full:4.8.9'
```

```groovy
implementation 'com.yodo1.mas:google:4.8.9'
```

```groovy
implementation 'com.yodo1.mas:lite:4.8.9'
```